### PR TITLE
Splitting robolimbs and prosthetics into different behaviors.

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,7 +47,7 @@
 #define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
 #define ORGAN_SABOTAGED  (1<<9)  // The organ will explode if exposed to EMP, if prosthetic.
 #define ORGAN_ASSISTED   (1<<10) // The organ is partially prosthetic. No mechanical effect.
-#define ORGAN_ROBOTIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_ROBOTIC for checks.
+#define ORGAN_PROSTHETIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
 #define ORGAN_BRITTLE    (1<<12) // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
 #define ORGAN_CRYSTAL    (1<<13) // The organ does not suffer laser damage, but shatters on droplimb.
 

--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -47,7 +47,7 @@
 #define ORGAN_DISFIGURED (1<<8)  // The organ is scarred/disfigured. Alters whether or not the face can be recognised.
 #define ORGAN_SABOTAGED  (1<<9)  // The organ will explode if exposed to EMP, if prosthetic.
 #define ORGAN_ASSISTED   (1<<10) // The organ is partially prosthetic. No mechanical effect.
-#define ORGAN_PROSTHETIC    (1<<11) // The organ is robotic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
+#define ORGAN_PROSTHETIC (1<<11) // The organ is prosthetic. Changes numerous behaviors, search BP_IS_PROSTHETIC for checks.
 #define ORGAN_BRITTLE    (1<<12) // The organ takes additional blunt damage. If robotic, cannot be repaired through normal means.
 #define ORGAN_CRYSTAL    (1<<13) // The organ does not suffer laser damage, but shatters on droplimb.
 

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -241,10 +241,10 @@
 #define BP_BY_DEPTH list(BP_HEAD, BP_L_HAND, BP_R_HAND, BP_L_ARM, BP_R_ARM, BP_L_FOOT, BP_R_FOOT, BP_L_LEG, BP_R_LEG, BP_GROIN, BP_CHEST)
 
 // Prosthetic helpers.
-#define BP_IS_ROBOTIC(org)  (org.status & ORGAN_ROBOTIC)
-#define BP_IS_ASSISTED(org) (org.status & ORGAN_ASSISTED)
-#define BP_IS_BRITTLE(org)  (org.status & ORGAN_BRITTLE)
-#define BP_IS_CRYSTAL(org)  (org.status & ORGAN_CRYSTAL)
+#define BP_IS_PROSTHETIC(org) (org.status & ORGAN_PROSTHETIC)
+#define BP_IS_ASSISTED(org)   (org.status & ORGAN_ASSISTED)
+#define BP_IS_BRITTLE(org)    (org.status & ORGAN_BRITTLE)
+#define BP_IS_CRYSTAL(org)    (org.status & ORGAN_CRYSTAL)
 
 // Limb flag helpers
 #define BP_IS_DEFORMED(org) (org.limb_flags & ORGAN_FLAG_DEFORMED)

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -20,7 +20,7 @@
 		var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
 		if(!heart)
 			pulse_result = 0
-		else if(BP_IS_ROBOTIC(heart))
+		else if(BP_IS_PROSTHETIC(heart))
 			pulse_result = -2
 		else if(H.status_flags & FAKEDEATH)
 			pulse_result = 0

--- a/code/datums/repositories/crew/binary.dm
+++ b/code/datums/repositories/crew/binary.dm
@@ -3,7 +3,7 @@
 	crew_data["alert"] = FALSE
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.internal_organs_by_name[BP_HEART]
-		if (!O || !BP_IS_ROBOTIC(O)) // Don't make medical freak out over prosthetic hearts
+		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			var/pulse = H.pulse()
 			if(pulse == PULSE_NONE || pulse == PULSE_THREADY)
 				crew_data["alert"] = TRUE

--- a/code/datums/repositories/crew/vital.dm
+++ b/code/datums/repositories/crew/vital.dm
@@ -5,7 +5,7 @@
 	crew_data["pulse_span"] = "neutral"
 	if(!H.isSynthetic() && H.should_have_organ(BP_HEART))
 		var/obj/item/organ/internal/heart/O = H.internal_organs_by_name[BP_HEART]
-		if (!O || !BP_IS_ROBOTIC(O)) // Don't make medical freak out over prosthetic hearts
+		if (!O || !BP_IS_PROSTHETIC(O)) // Don't make medical freak out over prosthetic hearts
 			crew_data["true_pulse"] = H.pulse()
 			crew_data["pulse"] = H.get_pulse(GETPULSE_TOOL)
 			switch(crew_data["true_pulse"])

--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -42,7 +42,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 		for(var/mob/living/carbon/human/H in SSmobs.mob_list)
 			if(H.stat != DEAD && !H.has_brain_worms())
 				var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-				if(head && !BP_IS_ROBOTIC(head))
+				if(head && !BP_IS_PROSTHETIC(head))
 					host = H
 					break
 		if(istype(host))

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -727,7 +727,7 @@ var/list/datum/absorbed_dna/hivemind_bank = list()
 			to_chat(src, "<span class='warning'>[T]'s armor has protected them.</span>")
 			return //thick clothes will protect from the sting
 
-	if(T.isSynthetic() || BP_IS_ROBOTIC(target_limb)) return
+	if(T.isSynthetic() || BP_IS_PROSTHETIC(target_limb)) return
 	if(!T.mind || !T.mind.changeling) return T	//T will be affected by the sting
 	to_chat(T, "<span class='warning'>You feel a tiny prick.</span>")
 	return

--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -270,7 +270,7 @@
 		return FALSE
 	if(initial(O.vital))
 		return FALSE
-	if(initial(O.status) & ORGAN_ROBOTIC)
+	if(initial(O.status) & ORGAN_PROSTHETIC)
 		return FALSE
 	if(ispath(organtype, /obj/item/organ/external))
 		var/obj/item/organ/external/E = organtype

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -59,7 +59,7 @@
 
 		for(var/bpart in shuffle(H.internal_organs_by_name - BP_BRAIN))
 			var/obj/item/organ/internal/regen_organ = H.internal_organs_by_name[bpart]
-			if(BP_IS_ROBOTIC(regen_organ))
+			if(BP_IS_PROSTHETIC(regen_organ))
 				continue
 			if(istype(regen_organ))
 				if(regen_organ.damage > 0 && !(regen_organ.status & ORGAN_DEAD))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -578,7 +578,7 @@ var/list/global/slot_flags_enumeration = list(
 		eyes.damage += rand(3,4)
 		if(eyes.damage >= eyes.min_bruised_damage)
 			if(M.stat != 2)
-				if(!BP_IS_ROBOTIC(eyes)) //robot eyes bleeding might be a bit silly
+				if(!BP_IS_PROSTHETIC(eyes)) //robot eyes bleeding might be a bit silly
 					to_chat(M, "<span class='danger'>Your eyes start to bleed profusely!</span>")
 			if(prob(50))
 				if(M.stat != 2)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -104,7 +104,7 @@
 	if(H == user)	//can't look into your own eyes buster
 		return
 
-	if(!BP_IS_ROBOTIC(vision))
+	if(!BP_IS_PROSTHETIC(vision))
 
 		if(vision.owner.stat == DEAD || H.blinded)	//mob is dead or fully blind
 			to_chat(user, "<span class='warning'>\The [H]'s pupils do not react to the light!</span>")

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -230,7 +230,7 @@
 		var/list/damaged = H.get_damaged_organs(1,1)
 		if(damaged.len)
 			for(var/obj/item/organ/external/org in damaged)
-				var/limb_result = "[capitalize(org.name)][BP_IS_ROBOTIC(org) ? " (Cybernetic)" : ""]:"
+				var/limb_result = "[capitalize(org.name)][BP_IS_PROSTHETIC(org) ? " (Cybernetic)" : ""]:"
 				if(org.brute_dam > 0)
 					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] physical trauma</b></font>\]"
 				if(org.burn_dam > 0)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -230,7 +230,7 @@
 		var/list/damaged = H.get_damaged_organs(1,1)
 		if(damaged.len)
 			for(var/obj/item/organ/external/org in damaged)
-				var/limb_result = "[capitalize(org.name)][BP_IS_PROSTHETIC(org) ? " (Cybernetic)" : ""]:"
+				var/limb_result = "[capitalize(org.name)][BP_IS_PROSTHETIC(org) ? " (prosthetic)" : ""]:"
 				if(org.brute_dam > 0)
 					limb_result = "[limb_result] \[<font color = 'red'><b>[get_wound_severity(org.brute_ratio, (org.limb_flags & ORGAN_FLAG_HEALS_OVERKILL))] physical trauma</b></font>\]"
 				if(org.burn_dam > 0)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -18,7 +18,7 @@
 	if(BP_IS_CRYSTAL(limb))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a crystalline limb."))
 	else if(BP_IS_PROSTHETIC(limb))
-		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a robotic limb."))
+		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a prosthetic limb."))
 	else
 		. = TRUE
 
@@ -260,7 +260,7 @@
 
 /obj/item/stack/medical/splint/check_limb_state(var/mob/user, var/obj/item/organ/external/limb)
 	if(BP_IS_PROSTHETIC(limb))
-		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a robotic limb."))
+		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a prosthetic limb."))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -17,7 +17,7 @@
 	. = FALSE
 	if(BP_IS_CRYSTAL(limb))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a crystalline limb."))
-	else if(BP_IS_ROBOTIC(limb))
+	else if(BP_IS_PROSTHETIC(limb))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a robotic limb."))
 	else
 		. = TRUE
@@ -259,7 +259,7 @@
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
 /obj/item/stack/medical/splint/check_limb_state(var/mob/user, var/obj/item/organ/external/limb)
-	if(BP_IS_ROBOTIC(limb))
+	if(BP_IS_PROSTHETIC(limb))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat a robotic limb."))
 		return FALSE
 	return TRUE
@@ -333,7 +333,7 @@
 	heal_burn =  5
 
 /obj/item/stack/medical/resin/check_limb_state(var/mob/user, var/obj/item/organ/external/limb)
-	if(!BP_IS_ROBOTIC(limb) && !BP_IS_CRYSTAL(limb))
+	if(!BP_IS_PROSTHETIC(limb) && !BP_IS_CRYSTAL(limb))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] to treat an organic limb."))
 		return FALSE
 	return TRUE

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -36,7 +36,7 @@
 			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
 			return
 
-		if(S && BP_IS_ROBOTIC(S) && S.hatch_state == HATCH_OPENED)
+		if(S && BP_IS_PROSTHETIC(S) && S.hatch_state == HATCH_OPENED)
 			if(!S.get_damage())
 				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
 			else if(can_use(1))

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -36,7 +36,7 @@
 			to_chat(user, "<span class='warning'>\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it.</span>")
 			return
 
-		if(S && BP_IS_PROSTHETIC(S) && S.hatch_state == HATCH_OPENED)
+		if(S && S.is_robotic() && S.hatch_state == HATCH_OPENED)
 			if(!S.get_damage())
 				to_chat(user, "<span class='notice'>Nothing to fix here.</span>")
 			else if(can_use(1))

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -81,7 +81,7 @@
 				var/picked = pick(check)
 				var/obj/item/organ/external/affecting = H.get_organ(picked)
 				if(affecting)
-					if(BP_IS_ROBOTIC(affecting))
+					if(BP_IS_PROSTHETIC(affecting))
 						return
 					affecting.take_external_damage(5, 0)
 					H.updatehealth()

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -282,7 +282,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
-		if(!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+		if(!S || !BP_IS_PROSTHETIC(S) || user.a_intent != I_HELP)
 			return ..()
 
 		if(BP_IS_BRITTLE(S))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -282,7 +282,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
-		if(!S || !BP_IS_PROSTHETIC(S) || user.a_intent != I_HELP)
+		if(!S || !S.is_robotic() || user.a_intent != I_HELP)
 			return ..()
 
 		if(BP_IS_BRITTLE(S))

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -135,7 +135,7 @@
 		if(!repaired_organ && prob(25))
 			for(var/thing in H.organs)
 				var/obj/item/organ/external/E = thing
-				if(BP_IS_ROBOTIC(E))
+				if(BP_IS_PROSTHETIC(E))
 					for(var/obj/implanted_object in E.implants)
 						if(!istype(implanted_object,/obj/item/weapon/implant) && !istype(implanted_object,/obj/item/organ/internal/augment) && prob(25))	// We don't want to remove REAL implants. Just shrapnel etc.
 							E.implants -= implanted_object

--- a/code/modules/augment/augment.dm
+++ b/code/modules/augment/augment.dm
@@ -3,7 +3,7 @@
 	desc = "Embedded augment."
 	icon = 'icons/obj/augment.dmi'
 	//By default these fit on both flesh and robotic organs and are robotic
-	status = ORGAN_ROBOTIC
+	status = ORGAN_PROSTHETIC
 	var/augment_flags = AUGMENTATION_MECHANIC | AUGMENTATION_ORGANIC
 	var/list/allowed_organs = list(BP_AUGMENT_R_ARM, BP_AUGMENT_L_ARM)
 	default_action_type = /datum/action/item_action/organ/augment

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -64,7 +64,7 @@
 		return 0
 	if(istype(user))
 		var/obj/item/organ/external/E = user.organs_by_name[BP_HEAD]
-		if(istype(E) && BP_IS_ROBOTIC(E))
+		if(istype(E) && BP_IS_PROSTHETIC(E))
 			return 1
 		to_chat(user, "<span class='warning'>You must have a robotic head to install this upgrade.</span>")
 	return 0

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -66,7 +66,7 @@
 		var/obj/item/organ/external/E = user.organs_by_name[BP_HEAD]
 		if(istype(E) && BP_IS_PROSTHETIC(E))
 			return 1
-		to_chat(user, "<span class='warning'>You must have a robotic head to install this upgrade.</span>")
+		to_chat(user, "<span class='warning'>You must have a prosthetic head to install this upgrade.</span>")
 	return 0
 
 /obj/item/clothing/mask/monitor/verb/set_monitor_state()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -234,7 +234,7 @@
 				if(LAZYLEN(E.wounds) && E.parent)
 					wound_flavor_text[E.name] += "[T.He] [T.has] [E.get_wounds_desc()] on [T.his] [E.parent.name].<br>"
 			else
-				if(!is_synth && BP_IS_ROBOTIC(E) && (E.parent && !BP_IS_ROBOTIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
+				if(!is_synth && BP_IS_PROSTHETIC(E) && (E.parent && !BP_IS_PROSTHETIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
 					wound_flavor_text[E.name] = "[T.He] [T.has] a [E.name].\n"
 				var/wounddesc = E.get_wounds_desc()
 				if(wounddesc != "nothing")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1332,7 +1332,7 @@
 		return 0
 
 	if(BP_IS_PROSTHETIC(affecting))
-		to_chat(user, "<span class='warning'>That limb is robotic.</span>")
+		to_chat(user, "<span class='warning'>That limb is prosthetic.</span>")
 		return 0
 
 	. = CAN_INJECT

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1331,7 +1331,7 @@
 		to_chat(user, "<span class='warning'>They are missing that limb.</span>")
 		return 0
 
-	if(BP_IS_ROBOTIC(affecting))
+	if(BP_IS_PROSTHETIC(affecting))
 		to_chat(user, "<span class='warning'>That limb is robotic.</span>")
 		return 0
 
@@ -1581,7 +1581,7 @@
 	else if(organ_check in list(BP_LIVER, BP_KIDNEYS))
 		affecting = organs_by_name[BP_GROIN]
 
-	if(affecting && BP_IS_ROBOTIC(affecting))
+	if(affecting && BP_IS_PROSTHETIC(affecting))
 		return 0
 	return (species && species.has_organ[organ_check])
 
@@ -1598,7 +1598,7 @@
 	. = ..()
 	var/obj/item/organ/internal/heart/H = internal_organs_by_name[BP_HEART]
 	if(H && !H.open)
-		. *= (!BP_IS_ROBOTIC(H)) ? pulse()/PULSE_NORM : 1.5
+		. *= (!BP_IS_PROSTHETIC(H)) ? pulse()/PULSE_NORM : 1.5
 
 /mob/living/carbon/human/need_breathe()
 	if(!(mNobreath in mutations) && species.breathing_organ && should_have_organ(species.breathing_organ))
@@ -1807,7 +1807,7 @@
 	var/obj/item/organ/external/E = get_organ(def_zone)
 	if(!E || E.is_stump())
 		return BULLET_IMPACT_NONE
-	if(BP_IS_ROBOTIC(E))
+	if(BP_IS_PROSTHETIC(E))
 		return BULLET_IMPACT_METAL
 	return BULLET_IMPACT_MEAT
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -306,7 +306,7 @@
 */
 /mob/living/carbon/human/proc/apply_pressure(mob/living/user, var/target_zone)
 	var/obj/item/organ/external/organ = get_organ(target_zone)
-	if(!organ || !(organ.status & ORGAN_BLEEDING) || BP_IS_ROBOTIC(organ))
+	if(!organ || !(organ.status & ORGAN_BLEEDING) || BP_IS_PROSTHETIC(organ))
 		return 0
 
 	if(organ.applied_pressure)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -71,7 +71,7 @@
 /mob/living/carbon/human/getBruteLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(BP_IS_ROBOTIC(O) && !O.vital)
+		if(BP_IS_PROSTHETIC(O) && !O.vital)
 			continue //robot limbs don't count towards shock and crit
 		amount += O.brute_dam
 	return amount
@@ -79,7 +79,7 @@
 /mob/living/carbon/human/getFireLoss()
 	var/amount = 0
 	for(var/obj/item/organ/external/O in organs)
-		if(BP_IS_ROBOTIC(O) && !O.vital)
+		if(BP_IS_PROSTHETIC(O) && !O.vital)
 			continue //robot limbs don't count towards shock and crit
 		amount += O.burn_dam
 	return amount

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -273,7 +273,7 @@ meteor_act
 
 /mob/living/carbon/human/emag_act(var/remaining_charges, mob/user, var/emag_source)
 	var/obj/item/organ/external/affecting = get_organ(user.zone_sel.selecting)
-	if(!affecting || !BP_IS_PROSTHETIC(affecting))
+	if(!affecting || !affecting.is_robotic())
 		to_chat(user, "<span class='warning'>That limb isn't robotic.</span>")
 		return -1
 	if(affecting.status & ORGAN_SABOTAGED)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -273,7 +273,7 @@ meteor_act
 
 /mob/living/carbon/human/emag_act(var/remaining_charges, mob/user, var/emag_source)
 	var/obj/item/organ/external/affecting = get_organ(user.zone_sel.selecting)
-	if(!affecting || !BP_IS_ROBOTIC(affecting))
+	if(!affecting || !BP_IS_PROSTHETIC(affecting))
 		to_chat(user, "<span class='warning'>That limb isn't robotic.</span>")
 		return -1
 	if(affecting.status & ORGAN_SABOTAGED)

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -182,7 +182,7 @@
 
 /mob/living/carbon/human/proc/stance_damage_prone(var/obj/item/organ/external/affected)
 
-	if(affected)
+	if(affected && (!BP_IS_PROSTHETIC(affected) || affected.is_robotic()))
 		switch(affected.body_part)
 			if(FOOT_LEFT, FOOT_RIGHT)
 				if(!BP_IS_PROSTHETIC(affected))
@@ -217,7 +217,7 @@
 	if(!unEquip(thing))
 		return
 
-	if(BP_IS_PROSTHETIC(affected))
+	if(affected.is_robotic())
 		visible_message("<B>\The [src]</B> drops what they were holding, \his [affected.name] malfunctioning!")
 
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -185,12 +185,12 @@
 	if(affected)
 		switch(affected.body_part)
 			if(FOOT_LEFT, FOOT_RIGHT)
-				if(!BP_IS_ROBOTIC(affected))
+				if(!BP_IS_PROSTHETIC(affected))
 					to_chat(src, SPAN_WARNING("You lose your footing as your [affected.name] spasms!"))
 				else
 					to_chat(src, SPAN_WARNING("You lose your footing as your [affected.name] [pick("twitches", "shudders")]!"))
 			if(LEG_LEFT, LEG_RIGHT)
-				if(!BP_IS_ROBOTIC(affected))
+				if(!BP_IS_PROSTHETIC(affected))
 					to_chat(src, SPAN_WARNING("Your [affected.name] buckles from the shock!"))
 				else
 					to_chat(src, SPAN_WARNING("You lose your balance as [affected.name] [pick("malfunctions", "freezes","shudders")]!"))
@@ -217,7 +217,7 @@
 	if(!unEquip(thing))
 		return
 
-	if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_PROSTHETIC(affected))
 		visible_message("<B>\The [src]</B> drops what they were holding, \his [affected.name] malfunctioning!")
 
 		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -234,7 +234,7 @@ var/global/list/damage_icon_parts = list()
 		O.update_icon()
 		if(O.damage_state == "00") continue
 		var/icon/DI
-		var/use_colour = (BP_IS_ROBOTIC(O) ? SYNTH_BLOOD_COLOUR : O.species.get_blood_colour(src))
+		var/use_colour = (BP_IS_PROSTHETIC(O) ? SYNTH_BLOOD_COLOUR : O.species.get_blood_colour(src))
 		var/cache_index = "[O.damage_state]/[O.icon_name]/[use_colour]/[species.get_bodytype(src)]"
 		if(damage_icon_parts[cache_index] == null)
 			DI = new /icon(species.get_damage_overlays(src), O.damage_state)			// the damage icon for whole human
@@ -322,7 +322,7 @@ var/global/list/damage_icon_parts = list()
 				icon_key += "#000000"
 			for(var/M in part.markings)
 				icon_key += "[M][part.markings[M]["color"]]"
-		if(BP_IS_ROBOTIC(part))
+		if(BP_IS_PROSTHETIC(part))
 			icon_key += "2[part.model ? "-[part.model]": ""]"
 		else if(part.status & ORGAN_DEAD)
 			icon_key += "3"
@@ -798,7 +798,7 @@ var/global/list/damage_icon_parts = list()
 	overlays_standing[HO_SURGERY_LAYER] = null
 	var/image/total = new
 	for(var/obj/item/organ/external/E in organs)
-		if(BP_IS_ROBOTIC(E) || E.is_stump())
+		if(BP_IS_PROSTHETIC(E) || E.is_stump())
 			continue
 		var/how_open = round(E.how_open())
 		if(how_open <= 0)

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -72,7 +72,7 @@
 			to_chat(user, "<span class='notice'>External prosthetics:</span>")
 			var/organ_found
 			for(var/obj/item/organ/external/E in H.organs)
-				if(!BP_IS_ROBOTIC(E))
+				if(!BP_IS_PROSTHETIC(E))
 					continue
 				organ_found = 1
 				to_chat(user, "[E.name]: <font color='red'>[E.brute_dam]</font> <font color='#ffa500'>[E.burn_dam]</font>")
@@ -82,7 +82,7 @@
 			to_chat(user, "<span class='notice'>Internal prosthetics:</span>")
 			organ_found = null
 			for(var/obj/item/organ/O in H.internal_organs)
-				if(!BP_IS_ROBOTIC(O))
+				if(!BP_IS_PROSTHETIC(O))
 					continue
 				organ_found = 1
 				to_chat(user, "[O.name]: <font color='red'>[O.damage]</font>")

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -305,7 +305,7 @@ Nurse caste procs
 		var/mob/living/carbon/human/H = .
 		if(prob(infest_chance) && max_eggs)
 			var/obj/item/organ/external/O = pick(H.organs)
-			if(!BP_IS_ROBOTIC(O) && !BP_IS_CRYSTAL(O) && (LAZYLEN(O.implants) < 2))
+			if(!BP_IS_PROSTHETIC(O) && !BP_IS_CRYSTAL(O) && (LAZYLEN(O.implants) < 2))
 				var/eggs = new /obj/effect/spider/eggcluster(O, src)
 				O.implants += eggs
 				max_eggs--

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -862,7 +862,7 @@
 		if(!surgical_removal)
 			shock_stage+=20
 			affected.take_external_damage((implant.w_class * 3), 0, DAM_EDGE, "Embedded object extraction")
-			if(!BP_IS_ROBOTIC(affected) && prob(implant.w_class * 5) && affected.sever_artery()) //I'M SO ANEMIC I COULD JUST -DIE-.
+			if(!BP_IS_PROSTHETIC(affected) && prob(implant.w_class * 5) && affected.sever_artery()) //I'M SO ANEMIC I COULD JUST -DIE-.
 				custom_pain("Something tears wetly in your [affected.name] as [implant] is pulled free!", 50, affecting = affected)
 	. = ..()
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -20,7 +20,7 @@
 	if(isnull(full_prosthetic))
 		robolimb_count = 0
 		for(var/obj/item/organ/external/E in organs)
-			if(BP_IS_ROBOTIC(E))
+			if(BP_IS_PROSTHETIC(E))
 				robolimb_count++
 		full_prosthetic = (robolimb_count == organs.len)
 		update_emotes()
@@ -624,7 +624,7 @@ proc/is_blind(A)
 	var/obj/item/organ/internal/heart/L = internal_organs_by_name[BP_HEART]
 	if(!istype(L))
 		return 0
-	if(BP_IS_ROBOTIC(L))
+	if(BP_IS_PROSTHETIC(L))
 		return 0//Robotic hearts don't get jittery.
 	if(src.jitteriness >= 400 && prob(5)) //Kills people if they have high jitters.
 		if(prob(1))

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -309,7 +309,7 @@
 	for (var/o in organs)
 		var/obj/item/organ/organ = o
 		organ.vital = 0
-		if (!BP_IS_ROBOTIC(organ))
+		if (!BP_IS_PROSTHETIC(organ))
 			organ.rejuvenate(1)
 			organ.max_damage *= 3
 			organ.min_broken_damage = Floor(organ.max_damage * 0.75)

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -71,12 +71,12 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 		else
 			var/organ_data = list("\[*\]")
 			for(var/obj/item/organ/external/E in H.organs)
-				if(BP_IS_ROBOTIC(E))
+				if(BP_IS_PROSTHETIC(E))
 					organ_data += "[E.model ? "[E.model] " : null][E.name] prosthetic"
 			for(var/obj/item/organ/internal/I in H.internal_organs)
 				if(BP_IS_ASSISTED(I))
 					organ_data += I.get_mechanical_assisted_descriptor()
-				else if (BP_IS_ROBOTIC(I))
+				else if (BP_IS_PROSTHETIC(I))
 					organ_data += "robotic [I.name] prosthetic"
 			set_implants(jointext(organ_data, "\[*\]"))
 

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -77,7 +77,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 				if(BP_IS_ASSISTED(I))
 					organ_data += I.get_mechanical_assisted_descriptor()
 				else if (BP_IS_PROSTHETIC(I))
-					organ_data += "robotic [I.name] prosthetic"
+					organ_data += "[I.name] prosthetic"
 			set_implants(jointext(organ_data, "\[*\]"))
 
 	// Security record

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -247,7 +247,7 @@
 		var/list/victims = list()
 		for(var/tag in list(BP_L_FOOT, BP_R_FOOT, BP_L_ARM, BP_R_ARM))
 			var/obj/item/organ/external/E = get_organ(tag)
-			if(E && !E.is_stump() && !E.dislocated && !BP_IS_ROBOTIC(E))
+			if(E && !E.is_stump() && !E.dislocated && !BP_IS_PROSTHETIC(E))
 				victims += E
 		if(victims.len)
 			var/obj/item/organ/external/victim = pick(victims)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -281,7 +281,7 @@ proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large,var/spra
 
 	var/recent_pump = LAZYACCESS(heart.external_pump, 1) > world.time - (20 SECONDS)
 	var/pulse_mod = 1
-	if((status_flags & FAKEDEATH) || BP_IS_ROBOTIC(heart))
+	if((status_flags & FAKEDEATH) || BP_IS_PROSTHETIC(heart))
 		pulse_mod = 1
 	else
 		switch(heart.pulse)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -146,7 +146,7 @@
 
 /obj/item/organ/external/emp_act(severity)
 
-	if(!BP_IS_PROSTHETIC(src))
+	if(!is_robotic())
 		return
 
 	if(owner && BP_IS_CRYSTAL(src)) // Crystalline robotics == piezoelectrics.
@@ -1154,7 +1154,7 @@ obj/item/organ/external/proc/remove_clamps()
 	return ..() && !is_stump() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || get_pain() < pain_disability_threshold) && brute_ratio < 1 && burn_ratio < 1
 
 /obj/item/organ/external/proc/is_malfunctioning()
-	return (BP_IS_PROSTHETIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
+	return (is_robotic() && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0, var/supplied_message, var/datum/wound/supplied_wound)
 	if(!owner || loc != owner)
@@ -1383,3 +1383,9 @@ obj/item/organ/external/proc/remove_clamps()
 		. += max_delay * 3/8
 	else if(BP_IS_PROSTHETIC(src))
 		. += max_delay * CLAMP01(damage/max_damage)
+
+/obj/item/organ/external/proc/is_robotic()
+	. = FALSE
+	if(BP_IS_PROSTHETIC(src) && model)
+		var/datum/robolimb/R = all_robolimbs[model]
+		. = R && R.is_robotic

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -79,7 +79,7 @@
 
 /obj/item/organ/external/proc/get_fingerprint()
 
-	if((limb_flags & ORGAN_FLAG_FINGERPRINT) && dna && !is_stump() && !BP_IS_ROBOTIC(src))
+	if((limb_flags & ORGAN_FLAG_FINGERPRINT) && dna && !is_stump() && !BP_IS_PROSTHETIC(src))
 		return md5(dna.uni_identity)
 
 	for(var/obj/item/organ/external/E in children)
@@ -146,7 +146,7 @@
 
 /obj/item/organ/external/emp_act(severity)
 
-	if(!BP_IS_ROBOTIC(src))
+	if(!BP_IS_PROSTHETIC(src))
 		return
 
 	if(owner && BP_IS_CRYSTAL(src)) // Crystalline robotics == piezoelectrics.
@@ -355,7 +355,7 @@
 
 //Helper proc used by various tools for repairing robot limbs
 /obj/item/organ/external/proc/robo_repair(var/repair_amount, var/damage_type, var/damage_desc, obj/item/tool, mob/living/user)
-	if((!BP_IS_ROBOTIC(src)))
+	if((!BP_IS_PROSTHETIC(src)))
 		return 0
 
 	var/damage_amount
@@ -480,7 +480,7 @@ This function completely restores a damaged organ to perfect condition.
 			owner.custom_pain("You feel something rip in your [name]!", 50, affecting = src)
 
 	//Burn damage can cause fluid loss due to blistering and cook-off
-	if((type in list(BURN, LASER)) && (damage > 5 || damage + burn_dam >= 15) && !BP_IS_ROBOTIC(src))
+	if((type in list(BURN, LASER)) && (damage > 5 || damage + burn_dam >= 15) && !BP_IS_PROSTHETIC(src))
 		var/fluid_loss_severity
 		switch(type)
 			if(BURN)  fluid_loss_severity = FLUIDLOSS_WIDE_BURN
@@ -505,7 +505,7 @@ This function completely restores a damaged organ to perfect condition.
 						owner.visible_message("<span class='danger'>The cracks in \the [owner]'s [name] spread.</span>",\
 						"<span class='danger'>The cracks in your [name] spread.</span>",\
 						"<span class='danger'>You hear the cracking of crystal.</span>")
-					else if(BP_IS_ROBOTIC(src))
+					else if(BP_IS_PROSTHETIC(src))
 						owner.visible_message("<span class='danger'>The damage to \the [owner]'s [name] worsens.</span>",\
 						"<span class='danger'>The damage to your [name] worsens.</span>",\
 						"<span class='danger'>You hear the screech of abused metal.</span>")
@@ -546,7 +546,7 @@ This function completely restores a damaged organ to perfect condition.
 		return 1
 	if(status & (ORGAN_CUT_AWAY|ORGAN_BLEEDING|ORGAN_BROKEN|ORGAN_DEAD|ORGAN_MUTATED))
 		return 1
-	if((brute_dam || burn_dam) && !BP_IS_ROBOTIC(src)) //Robot limbs don't autoheal and thus don't need to process when damaged
+	if((brute_dam || burn_dam) && !BP_IS_PROSTHETIC(src)) //Robot limbs don't autoheal and thus don't need to process when damaged
 		return 1
 	if(last_dam != brute_dam + burn_dam) // Process when we are fully healed up.
 		last_dam = brute_dam + burn_dam
@@ -596,7 +596,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 */
 /obj/item/organ/external/proc/update_germs()
 
-	if(BP_IS_ROBOTIC(src) || BP_IS_CRYSTAL(src) || (owner.species && owner.species.species_flags & SPECIES_FLAG_IS_PLANT)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
+	if(BP_IS_PROSTHETIC(src) || BP_IS_CRYSTAL(src) || (owner.species && owner.species.species_flags & SPECIES_FLAG_IS_PLANT)) //Robotic limbs shouldn't be infected, nor should nonexistant limbs.
 		germ_level = 0
 		return
 
@@ -655,12 +655,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		//spread the infection to child and parent organs
 		if (children)
 			for (var/obj/item/organ/external/child in children)
-				if (child.germ_level < germ_level && !BP_IS_ROBOTIC(child))
+				if (child.germ_level < germ_level && !BP_IS_PROSTHETIC(child))
 					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 						child.germ_level++
 
 		if (parent)
-			if (parent.germ_level < germ_level && !BP_IS_ROBOTIC(parent))
+			if (parent.germ_level < germ_level && !BP_IS_PROSTHETIC(parent))
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
 					parent.germ_level++
 
@@ -677,7 +677,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/update_wounds()
 
 	var/update_surgery
-	if(BP_IS_ROBOTIC(src) || BP_IS_CRYSTAL(src)) //Robotic limbs don't heal or get worse.
+	if(BP_IS_PROSTHETIC(src) || BP_IS_CRYSTAL(src)) //Robotic limbs don't heal or get worse.
 		for(var/datum/wound/W in wounds) //Repaired wounds disappear though
 			if(W.damage <= 0)  //and they disappear right away
 				qdel(W)    //TODO: robot wounds for robot limbs
@@ -735,7 +735,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		H = owner
 
 	//update damage counts
-	var/bleeds = (!BP_IS_ROBOTIC(src) && !BP_IS_CRYSTAL(src))
+	var/bleeds = (!BP_IS_PROSTHETIC(src) && !BP_IS_CRYSTAL(src))
 	for(var/datum/wound/W in wounds)
 
 		if(W.damage <= 0)
@@ -812,22 +812,22 @@ Note that amputating the affected organ does in fact remove the infection from t
 		switch(droptype)
 			if(DROPLIMB_EDGE)
 				if(!clean)
-					var/gore_sound = "[BP_IS_ROBOTIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
+					var/gore_sound = "[BP_IS_PROSTHETIC(src) ? "tortured metal" : "ripping tendons and flesh"]"
 					return list(
 						"\The [owner]'s [src.name] flies off in an arc!",
 						"Your [src.name] goes flying off!",
 						"You hear a terrible sound of [gore_sound]."
 						)
 			if(DROPLIMB_BURN)
-				var/gore = "[BP_IS_ROBOTIC(src) ? "": " of burning flesh"]"
+				var/gore = "[BP_IS_PROSTHETIC(src) ? "": " of burning flesh"]"
 				return list(
 					"\The [owner]'s [src.name] flashes away into ashes!",
 					"Your [src.name] flashes away into ashes!",
 					"You hear a crackling sound[gore]."
 					)
 			if(DROPLIMB_BLUNT)
-				var/gore = "[BP_IS_ROBOTIC(src) ? "": " in shower of gore"]"
-				var/gore_sound = "[BP_IS_ROBOTIC(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
+				var/gore = "[BP_IS_PROSTHETIC(src) ? "": " in shower of gore"]"
+				var/gore_sound = "[BP_IS_PROSTHETIC(src) ? "rending sound of tortured metal" : "sickening splatter of gore"]"
 				return list(
 					"\The [owner]'s [src.name] explodes[gore]!",
 					"Your [src.name] explodes[gore]!",
@@ -905,7 +905,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			var/obj/gore
 			if(BP_IS_CRYSTAL(src))
 				gore = new /obj/item/weapon/material/shard(get_turf(victim), MATERIAL_CRYSTAL)
-			else if(BP_IS_ROBOTIC(src))
+			else if(BP_IS_PROSTHETIC(src))
 				gore = new /obj/effect/decal/cleanable/blood/gibs/robot(get_turf(victim))
 			else
 				gore = new /obj/effect/decal/cleanable/blood/gibs(get_turf(victim))
@@ -1026,7 +1026,7 @@ obj/item/organ/external/proc/remove_clamps()
 /obj/item/organ/external/proc/fracture()
 	if(!config.bones_can_break)
 		return
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if((status & ORGAN_BROKEN) || !(limb_flags & ORGAN_FLAG_CAN_BREAK))
 		return
@@ -1056,7 +1056,7 @@ obj/item/organ/external/proc/remove_clamps()
 		suit.handle_fracture(owner, src)
 
 /obj/item/organ/external/proc/mend_fracture()
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return 0	//ORGAN_BROKEN doesn't have the same meaning for robot limbs
 	if(brute_dam > min_broken_damage * config.organ_health_multiplier)
 		return 0	//will just immediately fracture again
@@ -1090,7 +1090,7 @@ obj/item/organ/external/proc/remove_clamps()
 
 /obj/item/organ/external/robotize(var/company, var/skip_prosthetics = 0, var/keep_organs = 0)
 
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return
 
 	..()
@@ -1128,7 +1128,7 @@ obj/item/organ/external/proc/remove_clamps()
 		if(!keep_organs)
 			for(var/obj/item/organ/thing in internal_organs)
 				if(istype(thing))
-					if(thing.vital || BP_IS_ROBOTIC(thing))
+					if(thing.vital || BP_IS_PROSTHETIC(thing))
 						continue
 					internal_organs -= thing
 					owner.internal_organs_by_name[thing.organ_tag] = null
@@ -1154,7 +1154,7 @@ obj/item/organ/external/proc/remove_clamps()
 	return ..() && !is_stump() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || get_pain() < pain_disability_threshold) && brute_ratio < 1 && burn_ratio < 1
 
 /obj/item/organ/external/proc/is_malfunctioning()
-	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
+	return (BP_IS_PROSTHETIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))
 
 /obj/item/organ/external/proc/embed(var/obj/item/weapon/W, var/silent = 0, var/supplied_message, var/datum/wound/supplied_wound)
 	if(!owner || loc != owner)
@@ -1209,7 +1209,7 @@ obj/item/organ/external/proc/remove_clamps()
 			owner.drop_from_inventory(owner.wear_mask)
 
 	var/mob/living/carbon/human/victim = owner
-	var/is_robotic = BP_IS_ROBOTIC(src)
+	var/is_robotic = BP_IS_PROSTHETIC(src)
 
 	..()
 
@@ -1370,7 +1370,7 @@ obj/item/organ/external/proc/remove_clamps()
 	W.time_inflicted = world.time
 
 /obj/item/organ/external/proc/has_genitals()
-	return !BP_IS_ROBOTIC(src) && species && species.sexybits_location == organ_tag
+	return !BP_IS_PROSTHETIC(src) && species && species.sexybits_location == organ_tag
 
 // Added to the mob's move delay tally if this organ is being used to move with.
 /obj/item/organ/external/proc/movement_delay(max_delay)
@@ -1381,5 +1381,5 @@ obj/item/organ/external/proc/remove_clamps()
 		. += max_delay/8
 	else if(status & ORGAN_BROKEN)
 		. += max_delay * 3/8
-	else if(BP_IS_ROBOTIC(src))
+	else if(BP_IS_PROSTHETIC(src))
 		. += max_delay * CLAMP01(damage/max_damage)

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -4,7 +4,7 @@
 
 /obj/item/organ/external/proc/is_damageable(var/additional_damage = 0)
 	//Continued damage to vital organs can kill you, and robot organs don't count towards total damage so no need to cap them.
-	return (BP_IS_ROBOTIC(src) || brute_dam + burn_dam + additional_damage < max_damage * 4)
+	return (BP_IS_PROSTHETIC(src) || brute_dam + burn_dam + additional_damage < max_damage * 4)
 
 obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	take_external_damage(amount)
@@ -70,7 +70,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	// If the limbs can break, make sure we don't exceed the maximum damage a limb can take before breaking
 	var/datum/wound/created_wound
 	var/block_cut = (species.species_flags & SPECIES_FLAG_NO_MINOR_CUT) && brute <= 15
-	var/can_cut = !block_cut && !BP_IS_ROBOTIC(src) && (sharp || prob(brute))
+	var/can_cut = !block_cut && !BP_IS_PROSTHETIC(src) && (sharp || prob(brute))
 
 	if(brute)
 		var/to_create = BRUISE
@@ -131,7 +131,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 
 	var/damage_amt = brute
 	var/cur_damage = brute_dam
-	if(laser || BP_IS_ROBOTIC(src))
+	if(laser || BP_IS_PROSTHETIC(src))
 		damage_amt += burn
 		cur_damage += burn_dam
 
@@ -171,7 +171,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 		return TRUE
 
 /obj/item/organ/external/heal_damage(brute, burn, internal = 0, robo_repair = 0)
-	if(BP_IS_ROBOTIC(src) && !robo_repair)
+	if(BP_IS_PROSTHETIC(src) && !robo_repair)
 		return
 
 	//Heal damage on the individual wounds
@@ -203,10 +203,10 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 
 // Geneloss/cloneloss.
 /obj/item/organ/external/proc/get_genetic_damage()
-	return ((species && (species.species_flags & SPECIES_FLAG_NO_SCAN)) || BP_IS_ROBOTIC(src)) ? 0 : genetic_degradation
+	return ((species && (species.species_flags & SPECIES_FLAG_NO_SCAN)) || BP_IS_PROSTHETIC(src)) ? 0 : genetic_degradation
 
 /obj/item/organ/external/proc/remove_genetic_damage(var/amount)
-	if((species.species_flags & SPECIES_FLAG_NO_SCAN) || BP_IS_ROBOTIC(src))
+	if((species.species_flags & SPECIES_FLAG_NO_SCAN) || BP_IS_PROSTHETIC(src))
 		genetic_degradation = 0
 		status &= ~ORGAN_MUTATED
 		return
@@ -219,7 +219,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	return -(genetic_degradation - last_gene_dam)
 
 /obj/item/organ/external/proc/add_genetic_damage(var/amount)
-	if((species.species_flags & SPECIES_FLAG_NO_SCAN) || BP_IS_ROBOTIC(src))
+	if((species.species_flags & SPECIES_FLAG_NO_SCAN) || BP_IS_PROSTHETIC(src))
 		genetic_degradation = 0
 		status &= ~ORGAN_MUTATED
 		return
@@ -232,19 +232,19 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	return (genetic_degradation - last_gene_dam)
 
 /obj/item/organ/external/proc/mutate()
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return
 	src.status |= ORGAN_MUTATED
 	if(owner) owner.update_body()
 
 /obj/item/organ/external/proc/unmutate()
-	if(!BP_IS_DEFORMED(src) && !BP_IS_ROBOTIC(src))
+	if(!BP_IS_DEFORMED(src) && !BP_IS_PROSTHETIC(src))
 		src.status &= ~ORGAN_MUTATED
 		if(owner) owner.update_body()
 
 // Pain/halloss
 /obj/item/organ/external/proc/get_pain()
-	if(!can_feel_pain() || BP_IS_ROBOTIC(src))
+	if(!can_feel_pain() || BP_IS_PROSTHETIC(src))
 		return 0
 	var/lasting_pain = 0
 	if(is_broken())
@@ -310,13 +310,13 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 /obj/item/organ/external/proc/sever_artery()
 	if(species && species.has_organ[BP_HEART])
 		var/obj/item/organ/internal/heart/O = species.has_organ[BP_HEART]
-		if(!BP_IS_ROBOTIC(src) && !(status & ORGAN_ARTERY_CUT) && !initial(O.open))
+		if(!BP_IS_PROSTHETIC(src) && !(status & ORGAN_ARTERY_CUT) && !initial(O.open))
 			status |= ORGAN_ARTERY_CUT
 			return TRUE
 	return FALSE
 
 /obj/item/organ/external/proc/sever_tendon()
-	if((limb_flags & ORGAN_FLAG_HAS_TENDON) && !BP_IS_ROBOTIC(src) && !(status & ORGAN_TENDON_CUT))
+	if((limb_flags & ORGAN_FLAG_HAS_TENDON) && !BP_IS_PROSTHETIC(src) && !(status & ORGAN_TENDON_CUT))
 		status |= ORGAN_TENDON_CUT
 		return TRUE
 	return FALSE
@@ -326,7 +326,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	var/B = 1
 	if(A && istype(A))
 		B = A.brute_mult
-	if(!BP_IS_ROBOTIC(src))
+	if(!BP_IS_PROSTHETIC(src))
 		B *= species.get_brute_mod(owner)
 	var/blunt = !(damage_flags & DAM_EDGE|DAM_SHARP)
 	if(blunt && BP_IS_BRITTLE(src))
@@ -340,7 +340,7 @@ obj/item/organ/external/take_general_damage(var/amount, var/silent = FALSE)
 	var/B = 1
 	if(A && istype(A))
 		B = A.burn_mult
-	if(!BP_IS_ROBOTIC(src))
+	if(!BP_IS_PROSTHETIC(src))
 		B *= species.get_burn_mod(owner)
 	if(BP_IS_CRYSTAL(src))
 		B *= 0.1

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -17,7 +17,7 @@ var/list/limb_icon_cache = list()
 	s_col = null
 	s_base = ""
 	h_col = list(human.r_hair, human.g_hair, human.b_hair)
-	if(BP_IS_ROBOTIC(src) && !(human.species.appearance_flags & HAS_BASE_SKIN_COLOURS))
+	if(BP_IS_PROSTHETIC(src) && !(human.species.appearance_flags & HAS_BASE_SKIN_COLOURS))
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skintone))
 			return
@@ -35,7 +35,7 @@ var/list/limb_icon_cache = list()
 	s_col = null
 	s_base = dna.s_base
 	h_col = list(dna.GetUIValue(DNA_UI_HAIR_R),dna.GetUIValue(DNA_UI_HAIR_G),dna.GetUIValue(DNA_UI_HAIR_B))
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		var/datum/robolimb/franchise = all_robolimbs[model]
 		if(!(franchise && franchise.skintone))
 			return
@@ -83,7 +83,7 @@ var/list/limb_icon_cache = list()
 
 	if(force_icon)
 		icon = force_icon
-	else if (BP_IS_ROBOTIC(src))
+	else if (BP_IS_PROSTHETIC(src))
 		icon = 'icons/mob/human_races/cyberlimbs/robotic.dmi'
 	else if (!dna)
 		icon = 'icons/mob/human_races/species/human/body.dmi'
@@ -158,7 +158,7 @@ var/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888","#6666
 	if(min_dam_state && dam_state < min_dam_state)
 		dam_state = min_dam_state
 	// Apply colour and return product.
-	var/list/hud_colours = !BP_IS_ROBOTIC(src) ? flesh_hud_colours : robot_hud_colours
+	var/list/hud_colours = !BP_IS_PROSTHETIC(src) ? flesh_hud_colours : robot_hud_colours
 	hud_damage_image.color = hud_colours[max(1,min(ceil(dam_state*hud_colours.len),hud_colours.len))]
 	return hud_damage_image
 

--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -1,6 +1,6 @@
 
 /obj/item/organ/external/proc/get_wounds_desc()
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		var/list/descriptors = list()
 		if(brute_dam)
 			switch(brute_dam)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -110,7 +110,7 @@
 			var/image/eye_glow = get_eye_overlay()
 			if(eye_glow) overlays |= eye_glow
 
-		if(owner.lip_style && !BP_IS_ROBOTIC(src) && (species && (species.appearance_flags & HAS_LIPS)))
+		if(owner.lip_style && !BP_IS_PROSTHETIC(src) && (species && (species.appearance_flags & HAS_LIPS)))
 			var/icon/lip_icon = new/icon('icons/mob/human_races/species/human/lips.dmi', "lips_[owner.lip_style]_s")
 			overlays |= lip_icon
 			mob_icon.Blend(lip_icon, ICON_OVERLAY)

--- a/code/modules/organs/external/stump.dm
+++ b/code/modules/organs/external/stump.dm
@@ -16,7 +16,7 @@
 	..(holder, internal)
 	if(istype(limb))
 		max_damage = limb.max_damage
-		if(BP_IS_ROBOTIC(limb) && (!parent || BP_IS_ROBOTIC(parent)))
+		if(BP_IS_PROSTHETIC(limb) && (!parent || BP_IS_PROSTHETIC(parent)))
 			robotize() //if both limb and the parent are robotic, the stump is robotic too
 		if(BP_IS_CRYSTAL(limb) && (!parent || BP_IS_CRYSTAL(parent)))
 			status |= ORGAN_CRYSTAL // Likewise with crystalline limbs.

--- a/code/modules/organs/external/wounds/wound_types.dm
+++ b/code/modules/organs/external/wounds/wound_types.dm
@@ -279,7 +279,10 @@ datum/wound/puncture/massive
 			if(BP_IS_PROSTHETIC(lost_limb))
 				max_bleeding_stage = -1
 				bleed_threshold = INFINITY
-				stages = list("mangled robotic socket" = 0)
+				if(lost_limb.is_robotic())
+					stages = list("mangled robotic socket" = 0)
+				else
+					stages = list("mangled prosthetic socket" = 0)
 			else if(BP_IS_CRYSTAL(lost_limb))
 				max_bleeding_stage = -1
 				bleed_threshold = INFINITY

--- a/code/modules/organs/external/wounds/wound_types.dm
+++ b/code/modules/organs/external/wounds/wound_types.dm
@@ -276,7 +276,7 @@ datum/wound/puncture/massive
 	switch(losstype)
 		if(DROPLIMB_EDGE, DROPLIMB_BLUNT)
 			damage_type = CUT
-			if(BP_IS_ROBOTIC(lost_limb))
+			if(BP_IS_PROSTHETIC(lost_limb))
 				max_bleeding_stage = -1
 				bleed_threshold = INFINITY
 				stages = list("mangled robotic socket" = 0)

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -69,7 +69,7 @@
 		return 0 //organs don't work very well in the body when they aren't properly attached
 
 	// robotic organs emulate behavior of the equivalent flesh organ of the species
-	if(BP_IS_ROBOTIC(src) || !species)
+	if(BP_IS_PROSTHETIC(src) || !species)
 		species = target.species
 
 	..()
@@ -105,7 +105,7 @@
 	min_broken_damage += 10
 
 /obj/item/organ/internal/proc/getToxLoss()
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return damage * 0.5
 	return damage
 
@@ -127,7 +127,7 @@ obj/item/organ/internal/take_general_damage(var/amount, var/silent = FALSE)
 	take_internal_damage(amount, silent)
 
 /obj/item/organ/internal/proc/take_internal_damage(amount, var/silent=0)
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		damage = between(0, src.damage + (amount * 0.8), max_damage)
 	else
 		damage = between(0, src.damage + amount, max_damage)
@@ -164,7 +164,7 @@ obj/item/organ/internal/take_general_damage(var/amount, var/silent = FALSE)
 	handle_regeneration()
 
 /obj/item/organ/internal/proc/handle_regeneration()
-	if(!damage || BP_IS_ROBOTIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole())
+	if(!damage || BP_IS_PROSTHETIC(src) || !owner || owner.chem_effects[CE_TOXIN] || owner.is_asystole())
 		return
 	if(damage < 0.1*max_damage)
 		heal_damage(0.1)
@@ -189,7 +189,7 @@ obj/item/organ/internal/take_general_damage(var/amount, var/silent = FALSE)
 		. += "[get_wound_severity(get_scarring_level())] scarring"
 
 /obj/item/organ/internal/emp_act(severity)
-	if(!BP_IS_ROBOTIC(src))
+	if(!BP_IS_PROSTHETIC(src))
 		return
 	switch (severity)
 		if (1)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -39,7 +39,7 @@
 	..()
 
 /obj/item/organ/internal/heart/proc/handle_pulse()
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		pulse = PULSE_NONE	//that's it, you're dead (or your metal heart is), nothing can influence your pulse
 		return
 
@@ -120,13 +120,13 @@
 	if(!owner || owner.InStasis() || owner.stat == DEAD || owner.bodytemperature < 170)
 		return
 
-	if(pulse != PULSE_NONE || BP_IS_ROBOTIC(src))
+	if(pulse != PULSE_NONE || BP_IS_PROSTHETIC(src))
 		//Bleeding out
 		var/blood_max = 0
 		var/list/do_spray = list()
 		for(var/obj/item/organ/external/temp in owner.organs)
 
-			if(BP_IS_ROBOTIC(temp))
+			if(BP_IS_PROSTHETIC(temp))
 				continue
 
 			var/open_wound
@@ -193,10 +193,10 @@
 	if(!is_usable())
 		return FALSE
 
-	return pulse > PULSE_NONE || BP_IS_ROBOTIC(src) || (owner.status_flags & FAKEDEATH)
+	return pulse > PULSE_NONE || BP_IS_PROSTHETIC(src) || (owner.status_flags & FAKEDEATH)
 
 /obj/item/organ/internal/heart/listen()
-	if(BP_IS_ROBOTIC(src) && is_working())
+	if(BP_IS_PROSTHETIC(src) && is_working())
 		if(is_bruised())
 			return "sputtering pump"
 		else

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -38,7 +38,7 @@
 	if(is_broken())
 		filter_effect -= 2
 	// Robotic organs filter better but don't get benefits from dylovene for filtering.
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		filter_effect += 1
 	else if(owner.chem_effects[CE_ANTITOX])
 		filter_effect += 1

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -123,7 +123,7 @@
 	var/int_pressure_diff = abs(last_int_pressure - breath_pressure)
 	var/ext_pressure_diff = abs(last_ext_pressure - ext_pressure) * owner.get_pressure_weakness(ext_pressure)
 	if(int_pressure_diff > max_pressure_diff && ext_pressure_diff > max_pressure_diff)
-		var/lung_rupture_prob = BP_IS_ROBOTIC(src) ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
+		var/lung_rupture_prob = BP_IS_PROSTHETIC(src) ? prob(30) : prob(60) //Robotic lungs are less likely to rupture.
 		if(!is_bruised() && lung_rupture_prob) //only rupture if NOT already ruptured
 			rupture()
 
@@ -191,7 +191,7 @@
 	// Pass reagents from the gas into our body.
 	// Presumably if you breathe it you have a specialized metabolism for it, so we drop/ignore breath_type. Also avoids
 	// humans processing thousands of units of oxygen over the course of a round for the sole purpose of poisoning vox.
-	var/ratio = BP_IS_ROBOTIC(src)? 0.66 : 1
+	var/ratio = BP_IS_PROSTHETIC(src)? 0.66 : 1
 	for(var/gasname in breath.gas - breath_type)
 		var/breathed_product = gas_data.breathed_product[gasname]
 		if(breathed_product)
@@ -210,7 +210,7 @@
 	if(!failed_breath)
 		last_successful_breath = world.time
 		owner.adjustOxyLoss(-5 * inhale_efficiency)
-		if(!BP_IS_ROBOTIC(src) && species.breathing_sound && is_below_sound_pressure(get_turf(owner)))
+		if(!BP_IS_PROSTHETIC(src) && species.breathing_sound && is_below_sound_pressure(get_turf(owner)))
 			if(breathing || owner.shock_stage >= 10)
 				sound_to(owner, sound(species.breathing_sound,0,0,0,5))
 				breathing = 0
@@ -302,7 +302,7 @@
 	if(owner.failed_last_breath || !active_breathing)
 		return "no respiration"
 
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		if(is_bruised())
 			return "malfunctioning fans"
 		else

--- a/code/modules/organs/internal/species/adherent.dm
+++ b/code/modules/organs/internal/species/adherent.dm
@@ -108,7 +108,7 @@
 	icon = 'icons/mob/human_races/species/adherent/organs.dmi'
 	eye_icon = 'icons/mob/human_races/species/adherent/eyes.dmi'
 	icon_state = "eyes"
-	status = ORGAN_ROBOTIC
+	status = ORGAN_PROSTHETIC
 	phoron_guard = TRUE
 	innate_flash_protection = FLASH_PROTECTION_MAJOR
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -109,7 +109,7 @@ var/list/organ_cache = list()
 	if(is_preserved())
 		return
 	//Process infections
-	if (BP_IS_ROBOTIC(src) || (owner && owner.species && (owner.species.species_flags & SPECIES_FLAG_IS_PLANT)))
+	if (BP_IS_PROSTHETIC(src) || (owner && owner.species && (owner.species.species_flags & SPECIES_FLAG_IS_PLANT)))
 		germ_level = 0
 		return
 
@@ -185,7 +185,7 @@ var/list/organ_cache = list()
 	// immunosuppressant that changes transplant data to make it match.
 	if(owner.virus_immunity() < 10) //for now just having shit immunity will suppress it
 		return
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		return
 	if(dna)
 		if(!rejecting)
@@ -251,7 +251,7 @@ var/list/organ_cache = list()
 
 
 /obj/item/organ/proc/robotize() //Being used to make robutt hearts, etc
-	status = ORGAN_ROBOTIC
+	status = ORGAN_PROSTHETIC
 
 /obj/item/organ/proc/mechassist() //Used to add things like pacemakers, etc
 	status = ORGAN_ASSISTED
@@ -276,7 +276,7 @@ var/list/organ_cache = list()
 
 	START_PROCESSING(SSobj, src)
 	rejecting = null
-	if(!BP_IS_ROBOTIC(src))
+	if(!BP_IS_PROSTHETIC(src))
 		var/datum/reagent/blood/organ_blood = locate(/datum/reagent/blood) in reagents.reagent_list //TODO fix this and all other occurences of locate(/datum/reagent/blood) horror
 		if(!organ_blood || !organ_blood.data["blood_DNA"])
 			owner.vessel.trans_to(src, 5, 1, 1)
@@ -292,13 +292,13 @@ var/list/organ_cache = list()
 	owner = target
 	action_button_name = initial(action_button_name)
 	forceMove(owner) //just in case
-	if(BP_IS_ROBOTIC(src))
+	if(BP_IS_PROSTHETIC(src))
 		set_dna(owner.dna)
 	return 1
 
 /obj/item/organ/attack(var/mob/target, var/mob/user)
 
-	if(status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
+	if(status & ORGAN_PROSTHETIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 
 	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
@@ -317,7 +317,7 @@ var/list/organ_cache = list()
 	target.attackby(O, user)
 
 /obj/item/organ/proc/can_feel_pain()
-	return (!BP_IS_ROBOTIC(src) && (!species || !(species.species_flags & SPECIES_FLAG_NO_PAIN)))
+	return (!BP_IS_PROSTHETIC(src) && (!species || !(species.species_flags & SPECIES_FLAG_NO_PAIN)))
 
 /obj/item/organ/proc/is_usable()
 	return !(status & (ORGAN_CUT_AWAY|ORGAN_MUTATED|ORGAN_DEAD))
@@ -331,7 +331,7 @@ var/list/organ_cache = list()
 		. += tag ? "<span class='average'>Crystalline</span>" : "Crystalline"
 	else if(BP_IS_ASSISTED(src))
 		. += tag ? "<span class='average'>Assisted</span>" : "Assisted"
-	else if(BP_IS_ROBOTIC(src))
+	else if(BP_IS_PROSTHETIC(src))
 		. += tag ? "<span class='average'>Mechanical</span>" : "Mechanical"
 	if(status & ORGAN_CUT_AWAY)
 		. += tag ? "<span class='bad'>Severed</span>" : "Severed"

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -82,7 +82,7 @@ mob/living/carbon/human/proc/handle_pain()
 		custom_pain(msg, maxdam, prob(10), damaged_organ, TRUE)
 	// Damage to internal organs hurts a lot.
 	for(var/obj/item/organ/internal/I in internal_organs)
-		if(prob(1) && !((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) && I.damage > 5)
+		if(prob(1) && !((I.status & ORGAN_DEAD) || BP_IS_PROSTHETIC(I)) && I.damage > 5)
 			var/obj/item/organ/external/parent = get_organ(I.parent_organ)
 			var/pain = 10
 			var/message = "You feel a dull pain in your [parent.name]"

--- a/code/modules/organs/robolimbs.dm
+++ b/code/modules/organs/robolimbs.dm
@@ -29,6 +29,7 @@ var/datum/robolimb/basic_robolimb
 	var/hardiness = 1
 	var/fine_manipulation = TRUE
 	var/movement_slowdown = 0
+	var/is_robotic = TRUE
 
 /datum/robolimb/bishop
 	company = "Bishop"
@@ -121,9 +122,11 @@ var/datum/robolimb/basic_robolimb
 	desc = "A crude wooden prosthetic."
 	icon = 'icons/mob/human_races/cyberlimbs/morgan/morgan_main.dmi'
 	unavailable_at_fab = 1
+	modifier_string = "wooden"
 	hardiness = 0.75
 	fine_manipulation = FALSE
 	movement_slowdown = 1
+	is_robotic = FALSE
 
 /datum/robolimb/ying_wooden
 	company = "scavenged prosthesis"
@@ -135,10 +138,10 @@ var/datum/robolimb/basic_robolimb
 	hardiness = 0.75
 	fine_manipulation = FALSE
 	movement_slowdown = 2
+	is_robotic = FALSE
 
 /datum/robolimb/ying_metal
 	company = "Lunar Transit"
 	desc = "A cheap robotic prosthetic designed for yinglet owners."
 	icon = 'icons/mob/human_races/cyberlimbs/yinglet/metal_main.dmi'
 	allowed_bodytypes = list(SPECIES_YINGLET)
-	modifier_string = "wooden"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -520,7 +520,7 @@ obj/structure/cable/proc/cableColor(var/colorC)
 		var/obj/item/organ/external/S = H.organs_by_name[user.zone_sel.selecting]
 
 		if (!S) return
-		if(!BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+		if(!BP_IS_PROSTHETIC(S) || user.a_intent != I_HELP)
 			return ..()
 
 		if(BP_IS_BRITTLE(S))

--- a/code/modules/psionics/complexus/complexus_process.dm
+++ b/code/modules/psionics/complexus/complexus_process.dm
@@ -174,7 +174,7 @@
 			if(heal_internal)
 				for(var/obj/item/organ/I in H.internal_organs)
 
-					if(BP_IS_ROBOTIC(I) || BP_IS_CRYSTAL(I))
+					if(BP_IS_PROSTHETIC(I) || BP_IS_CRYSTAL(I))
 						continue
 
 					if(I.damage > 0 && spend_power(heal_rate))
@@ -187,7 +187,7 @@
 			if(H.bad_external_organs.len)
 				for(var/obj/item/organ/external/E in H.bad_external_organs)
 
-					if(BP_IS_ROBOTIC(E))
+					if(BP_IS_PROSTHETIC(E))
 						continue
 
 					if(heal_internal && (E.status & ORGAN_BROKEN) && E.damage < (E.min_broken_damage * config.organ_health_multiplier)) // So we don't mend and autobreak.

--- a/code/modules/psionics/faculties/redaction.dm
+++ b/code/modules/psionics/faculties/redaction.dm
@@ -56,7 +56,7 @@
 			to_chat(user, SPAN_WARNING("They are missing that limb."))
 			return TRUE
 
-		if(BP_IS_ROBOTIC(E))
+		if(BP_IS_PROSTHETIC(E))
 			to_chat(user, SPAN_WARNING("That limb is prosthetic."))
 			return TRUE
 
@@ -106,7 +106,7 @@
 
 		if(redaction_rank >= PSI_RANK_GRANDMASTER)
 			for(var/obj/item/organ/internal/I in E.internal_organs)
-				if(!BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
+				if(!BP_IS_PROSTHETIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
 					to_chat(user, SPAN_NOTICE("You encourage the damaged tissue of \the [I] to repair itself."))
 					var/heal_rate = redaction_rank
 					I.damage = max(0, I.damage - rand(heal_rate,heal_rate*2))

--- a/code/modules/psionics/null/chemistry.dm
+++ b/code/modules/psionics/null/chemistry.dm
@@ -32,7 +32,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/E in shuffle(H.organs.Copy()))
-			if(E.is_stump() || BP_IS_ROBOTIC(E))
+			if(E.is_stump() || BP_IS_PROSTHETIC(E))
 				continue
 
 			if(BP_IS_CRYSTAL(E))
@@ -59,7 +59,7 @@
 				break
 
 		for(var/obj/item/organ/internal/I in shuffle(H.internal_organs.Copy()))
-			if(BP_IS_ROBOTIC(I) || !BP_IS_CRYSTAL(I) || I.damage <= 0 || I.organ_tag == BP_BRAIN)
+			if(BP_IS_PROSTHETIC(I) || !BP_IS_CRYSTAL(I) || I.damage <= 0 || I.organ_tag == BP_BRAIN)
 				continue
 			if(prob(35))
 				to_chat(M, SPAN_NOTICE("You feel a deep, sharp tugging sensation as your [I.name] is mended."))

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -259,7 +259,7 @@
 	var/dam = rand(10, 15)
 	user.visible_message("<span class='danger'>\The [user]'s hand gets caught in \the [src]!</span>", "<span class='danger'>Your hand gets caught in \the [src]!</span>")
 	user.apply_damage(dam, BRUTE, hand, damage_flags = DAM_SHARP, used_weapon = "grinder")
-	if(BP_IS_ROBOTIC(hand_organ))
+	if(BP_IS_PROSTHETIC(hand_organ))
 		beaker.reagents.add_reagent(/datum/reagent/iron, dam)
 	else
 		user.take_blood(beaker, dam)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -172,7 +172,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			for(var/obj/item/organ/internal/I in H.internal_organs)
-				if(!BP_IS_ROBOTIC(I))
+				if(!BP_IS_PROSTHETIC(I))
 					I.heal_damage(20*removed)
 
 
@@ -200,7 +200,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			for(var/obj/item/organ/internal/I in H.internal_organs)
-				if(!BP_IS_ROBOTIC(I))
+				if(!BP_IS_PROSTHETIC(I))
 					I.heal_damage(30*removed)
 
 /datum/reagent/nanitefluid
@@ -219,7 +219,7 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			for(var/obj/item/organ/internal/I in H.internal_organs)
-				if(BP_IS_ROBOTIC(I))
+				if(BP_IS_PROSTHETIC(I))
 					I.heal_damage(20*removed)
 
 /* Painkillers */
@@ -435,7 +435,7 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/internal/I in H.internal_organs)
-			if(!BP_IS_ROBOTIC(I))
+			if(!BP_IS_PROSTHETIC(I))
 				if(I.organ_tag == BP_BRAIN)
 					if(I.damage >= I.min_bruised_damage)
 						continue

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -682,7 +682,7 @@
 	var/list/meatchunks = list()
 	for(var/limb_tag in list(BP_R_ARM, BP_L_ARM, BP_R_LEG,BP_L_LEG))
 		var/obj/item/organ/external/E = H.get_organ(limb_tag)
-		if(E && !E.is_stump() && !BP_IS_ROBOTIC(E) && E.species.name != SPECIES_PROMETHEAN)
+		if(E && !E.is_stump() && !BP_IS_PROSTHETIC(E) && E.species.name != SPECIES_PROMETHEAN)
 			meatchunks += E
 	if(!meatchunks.len)
 		if(prob(10))

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -67,7 +67,7 @@
 		if(!affected)
 			to_chat(user, "<span class='danger'>\The [H] is missing that limb!</span>")
 			return
-		else if(BP_IS_ROBOTIC(affected))
+		else if(BP_IS_PROSTHETIC(affected))
 			to_chat(user, "<span class='danger'>You cannot inject a robotic limb.</span>")
 			return
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -29,7 +29,7 @@
 		if(!affected)
 			to_chat(user, "<span class='danger'>\The [H] is missing that limb!</span>")
 			return
-		else if(BP_IS_ROBOTIC(affected))
+		else if(BP_IS_PROSTHETIC(affected))
 			to_chat(user, "<span class='danger'>You cannot inject a robotic limb.</span>")
 			return
 

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -64,7 +64,7 @@
 				H.custom_emote("rubs [T.his] [damaged_organ.name] carefully.")
 
 		for(var/obj/item/organ/I in H.internal_organs)
-			if((I.status & ORGAN_DEAD) || BP_IS_ROBOTIC(I)) continue
+			if((I.status & ORGAN_DEAD) || BP_IS_PROSTHETIC(I)) continue
 			if(I.damage > 2) if(prob(2))
 				var/obj/item/organ/external/parent = H.get_organ(I.parent_organ)
 				H.custom_emote("clutches [T.his] [parent.name]!")

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -151,8 +151,8 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 				affecting.heal_damage(amt_organ, amt_organ)
 		for(var/obj/item/organ/external/affecting in H.organs)
 			if(affecting && istype(affecting))
-				var/dam = BP_IS_ROBOTIC(affecting) ? -amt_dam_robo : amt_organ
-				affecting.heal_damage(dam, dam, robo_repair = BP_IS_ROBOTIC(affecting))
+				var/dam = BP_IS_PROSTHETIC(affecting) ? -amt_dam_robo : amt_organ
+				affecting.heal_damage(dam, dam, robo_repair = BP_IS_PROSTHETIC(affecting))
 		H.vessel.add_reagent(/datum/reagent/blood,amt_blood)
 		H.adjustBrainLoss(amt_brain)
 		H.radiation += min(H.radiation, amt_radiation)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -395,7 +395,7 @@
 		var/obj/item/organ/internal/eyes/eyes = subject.internal_organs_by_name[BP_EYES]
 		if (!eyes)
 			continue
-		if (BP_IS_ROBOTIC(eyes))
+		if (BP_IS_PROSTHETIC(eyes))
 			continue
 		if(subject.has_meson_effect())
 			continue

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -311,7 +311,7 @@
 /decl/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	var/target_zone = user.zone_sel.selecting
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_PROSTHETIC(affected))
 		return SURGERY_SKILLS_ROBOTIC
 	else
 		return ..()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -131,7 +131,7 @@
 		return
 	user.visible_message("<span class='notice'>[user] puts \the [tool] inside [target]'s [affected.cavity_name] cavity.</span>", \
 	"<span class='notice'>You put \the [tool] inside [target]'s [affected.cavity_name] cavity.</span>" )
-	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !BP_IS_ROBOTIC(affected) && affected.sever_artery())
+	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !BP_IS_PROSTHETIC(affected) && affected.sever_artery())
 		to_chat(user, "<span class='warning'>You tear some blood vessels trying to fit such a big object in this cavity.</span>")
 		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
 	affected.implants += tool
@@ -170,7 +170,7 @@
 	var/exposed = 0
 	if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED))
 		exposed = 1
-	if(BP_IS_ROBOTIC(affected) && affected.hatch_state == HATCH_OPENED)
+	if(BP_IS_PROSTHETIC(affected) && affected.hatch_state == HATCH_OPENED)
 		exposed = 1
 
 	var/find_prob = 0

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -35,7 +35,7 @@
 	var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
 	if(!P || P.is_stump())
 		to_chat(user, SPAN_WARNING("The [E.amputation_point] is missing!"))
-	else if(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E))
+	else if(BP_IS_PROSTHETIC(P) && !BP_IS_PROSTHETIC(E))
 		to_chat(user, SPAN_WARNING("You cannot attach a flesh part to a robotic body."))
 	else if(BP_IS_CRYSTAL(P) && !BP_IS_CRYSTAL(E))
 		to_chat(user, SPAN_WARNING("You cannot attach a flesh part to a crystalline body."))
@@ -45,7 +45,7 @@
 		. = TRUE
 
 /decl/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/organ/external/tool)
-	if(istype(tool) && BP_IS_ROBOTIC(tool))
+	if(istype(tool) && BP_IS_PROSTHETIC(tool))
 		if(target.isSynthetic())
 			return SURGERY_SKILLS_ROBOTIC
 		else
@@ -56,7 +56,7 @@
 	if(..())
 		var/obj/item/organ/external/E = tool
 		var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
-		. = (P && !P.is_stump() && !(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
+		. = (P && !P.is_stump() && !(BP_IS_PROSTHETIC(P) && !BP_IS_PROSTHETIC(E)))
 
 /decl/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = tool
@@ -96,7 +96,7 @@
 
 /decl/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	var/obj/item/organ/external/E = target && target.get_organ(target_zone)
-	if(istype(E) && BP_IS_ROBOTIC(E))
+	if(istype(E) && BP_IS_PROSTHETIC(E))
 		if(target.isSynthetic())
 			return SURGERY_SKILLS_ROBOTIC
 		else

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -41,7 +41,7 @@
 	user.visible_message("[user] starts treating damage within \the [target]'s [affected.name] with [tool_name].", \
 	"You start treating damage within \the [target]'s [affected.name] with [tool_name]." )
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (!I.status & ORGAN_DEAD || I.can_recover()) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
+		if(I && I.damage > 0 && !BP_IS_PROSTHETIC(I) && (!I.status & ORGAN_DEAD || I.can_recover()) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
 			user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 			"You start treating damage to [target]'s [I.name] with [tool_name]." )
 	target.custom_pain("The pain in your [affected.name] is living hell!",100,affecting = affected)
@@ -55,7 +55,7 @@
 		tool_name = "the bandaid"
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
+		if(I && I.damage > 0 && !BP_IS_PROSTHETIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
 			if(I.status & ORGAN_DEAD && I.can_recover())
 				user.visible_message("<span class='notice'>\The [user] treats damage to [target]'s [I.name] with [tool_name], though it needs to be recovered further.</span>", \
 				"<span class='notice'>You treat damage to [target]'s [I.name] with [tool_name], though it needs to be recovered further.</span>" )
@@ -78,7 +78,7 @@
 		target.adjustToxLoss(10)
 		affected.take_external_damage(dam_amt, 0, (DAM_SHARP|DAM_EDGE), used_weapon = tool)
 	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
+		if(I && I.damage > 0 && !BP_IS_PROSTHETIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
 			I.take_internal_damage(dam_amt)
 
 //////////////////////////////////////////////////////////////////
@@ -165,8 +165,8 @@
 	var/target_zone = user.zone_sel.selecting
 	var/obj/item/organ/internal/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(O))
-		if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_PROSTHETIC(O))
+		if(BP_IS_PROSTHETIC(affected))
 			return SURGERY_SKILLS_ROBOTIC
 		else
 			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
@@ -190,7 +190,7 @@
 	if(istype(O) && istype(affected))
 		affected.implants -= O
 		O.dropInto(target.loc)
-		if(!BP_IS_ROBOTIC(affected))
+		if(!BP_IS_PROSTHETIC(affected))
 			playsound(target.loc, 'sound/effects/squelch1.ogg', 15, 1)
 		else
 			playsound(target.loc, 'sound/items/Ratchet.ogg', 50, 1)
@@ -224,8 +224,8 @@
 /decl/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	var/obj/item/organ/internal/O = tool
 	var/obj/item/organ/external/affected = target.get_organ(user.zone_sel.selecting)
-	if(BP_IS_ROBOTIC(O))
-		if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_PROSTHETIC(O))
+		if(BP_IS_PROSTHETIC(affected))
 			return SURGERY_SKILLS_ROBOTIC
 		else
 			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
@@ -241,7 +241,7 @@
 			to_chat(user, SPAN_WARNING("You cannot install a crystalline organ into a non-crystalline bodypart."))
 		else if(!BP_IS_CRYSTAL(O) && BP_IS_CRYSTAL(affected))
 			to_chat(user, SPAN_WARNING("You cannot install a non-crystalline organ into a crystalline bodypart."))
-		else if(BP_IS_ROBOTIC(affected) && !BP_IS_ROBOTIC(O))
+		else if(BP_IS_PROSTHETIC(affected) && !BP_IS_PROSTHETIC(O))
 			to_chat(user, SPAN_WARNING("You cannot install a naked organ into a robotic body."))
 		else if(!target.species)
 			CRASH("Target ([target]) of surgery [type] has no species!")
@@ -306,8 +306,8 @@
 	var/target_zone = user.zone_sel.selecting
 	var/obj/item/organ/internal/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(O))
-		if(BP_IS_ROBOTIC(affected))
+	if(BP_IS_PROSTHETIC(O))
+		if(BP_IS_PROSTHETIC(affected))
 			return SURGERY_SKILLS_ROBOTIC
 		else
 			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
@@ -340,7 +340,7 @@
 			to_chat(user, SPAN_WARNING("\The [A] cannot function within a non-robotic limb."))
 			return FALSE
 
-	if(BP_IS_ROBOTIC(organ_to_replace) && target.species.spawn_flags & SPECIES_NO_ROBOTIC_INTERNAL_ORGANS)
+	if(BP_IS_PROSTHETIC(organ_to_replace) && target.species.spawn_flags & SPECIES_NO_ROBOTIC_INTERNAL_ORGANS)
 		user.visible_message("<span class='notice'>[target]'s biology has rejected the attempts to attach \the [organ_to_replace].</span>")
 		return FALSE
 
@@ -400,7 +400,7 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/obj/item/organ/internal/list/dead_organs = list()
 	for(var/obj/item/organ/internal/I in target.internal_organs)
-		if(I && !(I.status & ORGAN_CUT_AWAY) && (I.status & ORGAN_DEAD) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
+		if(I && !(I.status & ORGAN_CUT_AWAY) && (I.status & ORGAN_DEAD) && I.parent_organ == affected.organ_tag && !BP_IS_PROSTHETIC(I))
 			dead_organs |= I
 	if(!dead_organs.len)
 		return FALSE

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -354,7 +354,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	var/obj/item/organ/external/affected = ..()
 	if(affected)
 		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
+			if(BP_IS_PROSTHETIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
 				if(I.surface_accessible)
 					return affected
 				if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED) || affected.hatch_state == HATCH_OPENED)
@@ -364,7 +364,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I))
+			if(BP_IS_PROSTHETIC(I))
 				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
 				"You start mending the damage to [target]'s [I.name]'s mechanisms." )
 	..()
@@ -373,7 +373,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.internal_organs)
 		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I))
+			if(BP_IS_PROSTHETIC(I))
 				user.visible_message("<span class='notice'>[user] repairs [target]'s [I.name] with [tool].</span>", \
 				"<span class='notice'>You repair [target]'s [I.name] with [tool].</span>" )
 				I.damage = 0
@@ -447,7 +447,7 @@ decl/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/hum
 	var/list/removable_organs = list()
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	for(var/obj/item/organ/I in affected.implants)
-		if ((I.status & ORGAN_CUT_AWAY) && BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && (I.parent_organ == target_zone))
+		if ((I.status & ORGAN_CUT_AWAY) && BP_IS_PROSTHETIC(I) && !BP_IS_CRYSTAL(I) && (I.parent_organ == target_zone))
 			removable_organs |= I.organ_tag
 	var/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in removable_organs
 	if(!organ_to_replace)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -72,13 +72,13 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 				to_chat(user,SPAN_NOTICE("The material covering this area is too thick for you to do surgery through!"))
 				return FALSE
 			// Check various conditional flags.
-			if(((surgery_candidate_flags & SURGERY_NO_ROBOTIC) && BP_IS_ROBOTIC(affected)) || \
+			if(((surgery_candidate_flags & SURGERY_NO_ROBOTIC) && BP_IS_PROSTHETIC(affected)) || \
 			 ((surgery_candidate_flags & SURGERY_NO_CRYSTAL) && BP_IS_CRYSTAL(affected))   || \
 			 ((surgery_candidate_flags & SURGERY_NO_STUMP) && affected.is_stump())         || \
-			 ((surgery_candidate_flags & SURGERY_NO_FLESH) && !(BP_IS_ROBOTIC(affected) || BP_IS_CRYSTAL(affected))))
+			 ((surgery_candidate_flags & SURGERY_NO_FLESH) && !(BP_IS_PROSTHETIC(affected) || BP_IS_CRYSTAL(affected))))
 				return FALSE
 			// Check if the surgery target is accessible.
-			if(BP_IS_ROBOTIC(affected))
+			if(BP_IS_PROSTHETIC(affected))
 				if(((surgery_candidate_flags & SURGERY_NEEDS_ENCASEMENT) || \
 				 (surgery_candidate_flags & SURGERY_NEEDS_INCISION)      || \
 				 (surgery_candidate_flags & SURGERY_NEEDS_RETRACTED))    && \

--- a/code/modules/xenoarcheaology/triggers/touch.dm
+++ b/code/modules/xenoarcheaology/triggers/touch.dm
@@ -35,7 +35,7 @@
 		if(H.isSynthetic())
 			return TRUE
 		var/obj/item/organ/external/E = H.get_organ(bodypart)
-		if(E && BP_IS_ROBOTIC(E))
+		if(E && BP_IS_PROSTHETIC(E))
 			return TRUE
 		return FALSE
 		


### PR DESCRIPTION
Splits prosthetic behavior up into prosthetic vs electronic, checked with `is_electronic()` on `/organ/external`, and renames the `BP_IS_ROBOTIC` and `ORGAN_ROBOTIC` macros to `BP_IS_PROSTHETIC` and `ORGAN_PROSTHETIC`.
Fixes #34.