### PR TITLE
Adjusting smelting and materials to be slightly more straightforward.

### DIFF
--- a/code/modules/materials/definitions/materials_glass.dm
+++ b/code/modules/materials/definitions/materials_glass.dm
@@ -45,6 +45,6 @@
 	wire_product = null
 	construction_difficulty = MATERIAL_HARD_DIY
 	alloy_product = TRUE
-	alloy_materials = list(MATERIAL_SAND = 2500, MATERIAL_PLATINUM = 1250)
+	alloy_materials = list(MATERIAL_GLASS = 2500, MATERIAL_PLATINUM = 1250)
 	sale_price = 2
 	value = 40

--- a/code/modules/materials/definitions/materials_metal.dm
+++ b/code/modules/materials/definitions/materials_metal.dm
@@ -120,7 +120,7 @@
 				/datum/reagent/iron = 19.6,
 				/datum/reagent/carbon = 0.4
 				)
-	alloy_materials = list(MATERIAL_HEMATITE = 1875, MATERIAL_GRAPHITE = 1875)
+	alloy_materials = list(MATERIAL_IRON = 1875, MATERIAL_GRAPHITE = 1875)
 	alloy_product = TRUE
 	sale_price = 1
 	ore_smelts_to = MATERIAL_STEEL

--- a/code/modules/materials/definitions/materials_mineral.dm
+++ b/code/modules/materials/definitions/materials_mineral.dm
@@ -26,15 +26,14 @@
 	name = MATERIAL_GRAPHITE
 	ore_compresses_to = MATERIAL_GRAPHITE
 	icon_colour = "#444444"
-	ore_smelts_to = MATERIAL_PLASTIC
 	ore_name = "graphite"
-	ore_smelts_to = MATERIAL_PLASTIC
 	ore_result_amount = 5
 	ore_spread_chance = 25
 	ore_scan_icon = "mineral_common"
 	ore_icon_overlay = "lump"
 	chem_products = list(
 		/datum/reagent/carbon = 15,
+		/datum/reagent/toxin/plasticide = 5,
 		/datum/reagent/acetone = 5
 		)
 	sale_price = 1


### PR DESCRIPTION
- Borosilicate glass is alloyed from glass instead of sand.
- Steel is alloyed from iron instead of hematite.
- Graphite now contains plasticide, rather than smelting to it.

This is foundation work for some simple smelting and alloying machines I'm working on - the convoluted alloying conditions made it impossible to combine smelting and alloying in one operation.