### PR TITLE
Travis: Move away from using system python by using PyEnv supplied by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ addons:
       - libc6-i386
       - libgcc1:i386
       - libstdc++6:i386
-      - python
-      - python-pip
+      - libyaml-dev
       - uchardet
 
 script:

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -164,8 +164,7 @@ function find_code_deps {
     need_cmd grep
     need_cmd awk
     need_cmd md5sum
-    need_cmd python3
-    need_cmd pip
+    need_cmd pyenv
 }
 
 function find_web_deps {
@@ -193,11 +192,17 @@ function find_code {
     fi
 }
 
+function setup_python3 {
+    pyenv global 3.6.7
+    pip3 install --upgrade pip -q
+    pip3 install pyyaml==5.3 -q
+    pip3 install beautifulsoup4==4.8.2 -q
+}
+
 function run_code_tests {
     msg "*** running code tests ***"
     find_code_deps
-    pip install --user PyYaml -q
-    pip install --user beautifulsoup4 -q
+    setup_python3
     shopt -s globstar
     run_test "check travis contains all maps" "scripts/validateTravisContainsAllMaps.sh"
     run_test_fail "maps contain no step_[xy]" "grep 'step_[xy]' maps/**/*.dmm"


### PR DESCRIPTION
the apt pip package is the python2 version of pip which installs all of that noise and generates a deprecation warning since python2 is officially dead come 2020, I guess installing under the user account didn't break anything with the two modules that were installed, they are however necessary.

* Change the travis package requirement from pip to pip3
* Lock python package versions (remember to update those as necessary)