### PR TITLE
Radstorm event tweaks.

### DIFF
--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -12,35 +12,6 @@ var/hadevent    = 0
 			A.update_icon()
 			break
 
-/proc/high_radiation_event()
-
-/* // Haha, this is way too laggy. I'll keep the prison break though.
-	for(var/obj/machinery/light/L in world)
-		if(isNotStationLevel(L.z)) continue
-		L.flicker(50)
-
-	sleep(100)
-*/
-	for(var/mob/living/carbon/human/H in GLOB.living_mob_list_)
-		var/turf/T = get_turf(H)
-		if(!T)
-			continue
-		if(isNotStationLevel(T.z))
-			continue
-		if(istype(H,/mob/living/carbon/human))
-			H.apply_damage((rand(15,75)),IRRADIATE, damage_flags = DAM_DISPERSED)
-			if (prob(5))
-				H.apply_damage((rand(90,150)),IRRADIATE, damage_flags = DAM_DISPERSED)
-			if (prob(25))
-				if (prob(75))
-					randmutb(H)
-					domutcheck(H,null,MUTCHK_FORCED)
-				else
-					randmutg(H)
-					domutcheck(H,null,MUTCHK_FORCED)
-	sleep(100)
-	GLOB.using_map.radiation_detected_announcement()
-
 /proc/carp_migration() // -- Darem
 	for(var/obj/effect/landmark/C in landmarks_list)
 		if(C.name == "carpspawn")

--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -19,7 +19,7 @@
 		return res
 
 /datum/event/radiation_storm/announce()
-	command_announcement.Announce("High levels of radiation detected in proximity of the [location_name()]. Please evacuate into one of the shielded maintenance tunnels.", "[location_name()] Sensor Array", new_sound = GLOB.using_map.radiation_detected_sound, zlevels = affecting_z)
+	GLOB.using_map.radiation_detected_announcement()
 
 /datum/event/radiation_storm/start()
 	..()

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -19,14 +19,17 @@
 /area/ship/scrap/crew/dorms1
 	name = "\improper Crew Cabin #1"
 	icon_state = "green"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/ship/scrap/crew/dorms2
 	name = "\improper Crew Cabin #2"
 	icon_state = "purple"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/ship/scrap/crew/dorms3
 	name = "\improper Crew Cabin #3"
 	icon_state = "yellow"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/ship/scrap/crew/saloon
 	name = "\improper Saloon"
@@ -44,10 +47,12 @@
 /area/ship/scrap/crew/medbay
 	name = "\improper Medical Bay"
 	icon_state = "medbay"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/ship/scrap/cargo
 	name = "\improper Cargo Hold"
 	icon_state = "quartstorage"
+	area_flags = AREA_FLAG_RAD_SHIELDED
 
 /area/ship/scrap/cargo/lower
 	name = "\improper Lower Cargo Hold"

--- a/maps/tradeship/tradeship_define.dm
+++ b/maps/tradeship/tradeship_define.dm
@@ -32,6 +32,9 @@
 	department_money = 0
 	salary_modifier = 0.2
 
+	radiation_detected_message = "High levels of radiation have been detected in proximity of the %STATION_NAME%. Please move to a shielded area such as the cargo bay, dormitories or medbay until the radiation has passed."
+	
+
 /datum/map/tradeship/get_map_info()
 	return "You're aboard the <b>[station_name],</b> a survey and mercantile vessel affiliated with <b>Tradehouse Ivenmoth</b>, a large merchant guild operating out of Val Salia Station. \
 	No meaningful authorities can claim the planets and resources in this uncharted sector, so their exploitation is entirely up to you - mine, poach and deforest all you want."


### PR DESCRIPTION
- Cargo bay, medical bay and dorms on Tradeship are now shielded.
- Radstorm event is more informative about where you can hide.

Closes #100.