### PR TITLE
Switched GC fail from crash_with to to_world_log. 

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -190,7 +190,7 @@ SUBSYSTEM_DEF(garbage)
 				var/type = D.type
 				var/datum/qdel_item/I = items[type]
 				if(!I.failures)
-					crash_with("GC: -- \ref[D] | [type] was unable to be GC'd --")
+					to_world_log("GC: -- \ref[D] | [type] was unable to be GC'd --")
 				I.failures++
 				fail_counts[level]++
 			if (GC_QUEUE_HARDDELETE)


### PR DESCRIPTION
Stack trace is pointless and it spams the hell out of the runtime logs.