### PR TITLE
Molotov cocktail and general fuel reagent refactor.

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -1,5 +1,6 @@
 /obj/effect/decal/cleanable/liquid_fuel
 	//Liquid fuel is used for things that used to rely on volatile fuels or phoron being contained to a couple tiles.
+	name = "flammable liquid"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "fuel"
 	layer = BLOOD_LAYER
@@ -7,6 +8,11 @@
 	cleanable_scent = "fuel"
 
 /obj/effect/decal/cleanable/liquid_fuel/proc/Spread(exclude=list())
+
+	// Ooze down to the lowest available area.
+	while(HasBelow(loc.z) && istype(loc, /turf/simulated/open))
+		dropInto(GetBelow(loc))
+
 	//Allows liquid fuels to sometimes flow into other tiles.
 	if(amount < 15) return //lets suppose welder fuel is fairly thick and sticky. For something like water, 5 or less would be more appropriate.
 	var/turf/simulated/S = loc
@@ -35,6 +41,11 @@
 	. = ..()
 
 /obj/effect/decal/cleanable/liquid_fuel/flamethrower_fuel/Spread()
+
+	// Ooze down to the lowest available area.
+	while(HasBelow(loc.z) && istype(loc, /turf/simulated/open))
+		dropInto(GetBelow(loc))
+
 	//The spread for flamethrower fuel is much more precise, to create a wide fire pattern.
 	if(amount < 0.1) return
 	var/turf/simulated/S = loc

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -20,8 +20,8 @@ atom/proc/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed
 /mob/is_burnable()
 	return simulated
 
-turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
-
+/turf/proc/hotspot_expose(exposed_temperature, exposed_volume, soh = 0)
+	return
 
 /turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, soh)
 	if(fire_protection > world.time-300)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -41,6 +41,7 @@
 	var/heating_point
 	var/heating_message = "begins to boil!"
 	var/heating_sound = 'sound/effects/bubbles.ogg'
+	var/fuel_value = 0
 
 	var/temperature_multiplier = 1
 	var/value = 1
@@ -64,15 +65,22 @@
 /datum/reagent/proc/on_leaving_metabolism(var/mob/parent, var/metabolism_class)
 	return
 
-// This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
-/datum/reagent/proc/touch_mob(var/mob/M, var/amount)
-	return
-
 /datum/reagent/proc/touch_obj(var/obj/O, var/amount) // Acid melting, cleaner cleaning, etc
 	return
 
+#define FLAMMABLE_LIQUID_DIVISOR 7
+// This doesn't apply to skin contact - this is for, e.g. extinguishers and sprays. The difference is that reagent is not directly on the mob's skin - it might just be on their clothing.
+/datum/reagent/proc/touch_mob(var/mob/living/M, var/amount)
+	if(fuel_value && amount && istype(M))
+		M.fire_stacks += Floor((amount * fuel_value)/FLAMMABLE_LIQUID_DIVISOR)
+
 /datum/reagent/proc/touch_turf(var/turf/T, var/amount) // Cleaner cleaning, lube lubbing, etc, all go here
-	return
+	if(fuel_value && istype(T))
+		var/removing = Floor((amount * fuel_value)/FLAMMABLE_LIQUID_DIVISOR)
+		if(removing > 0)
+			new /obj/effect/decal/cleanable/liquid_fuel(T, removing)
+			remove_self(removing)
+#undef FLAMMABLE_LIQUID_DIVISOR
 
 /datum/reagent/proc/on_mob_life(var/mob/living/carbon/M, var/alien, var/location) // Currently, on_mob_life is called on carbons. Any interaction with non-carbon mobs (lube) will need to be done in touch_mob.
 	if(QDELETED(src))

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -197,22 +197,14 @@
 	reagent_state = LIQUID
 	color = "#660000"
 	touch_met = 5
+	fuel_value = 1
 
 	glass_name = "welder fuel"
 	glass_desc = "Unless you are an industrial tool, this is probably not safe for consumption."
 	value = 6.8
 
-/datum/reagent/fuel/touch_turf(var/turf/T)
-	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
-	remove_self(volume)
-	return
-
 /datum/reagent/fuel/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(2 * removed)
-
-/datum/reagent/fuel/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / 10) // Splashing people with welding fuel to make them easy to ignite!
 
 /datum/reagent/fuel/ex_act(obj/item/chems/holder, severity)
 	if(volume <= 50)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -91,6 +91,8 @@
 	reagent_state = LIQUID
 	color = "#404030"
 	touch_met = 5
+	fuel_value = 0.75
+
 	var/nutriment_factor = 0
 	var/hydration_factor = 0
 	var/strength = 10 // This is, essentially, units between stages - the lower, the stronger. Less fine tuning, more clarity.
@@ -104,10 +106,6 @@
 	glass_name = "ethanol"
 	glass_desc = "A well-known alcohol with a variety of applications."
 	value = DISPENSER_REAGENT_VALUE
-
-/datum/reagent/ethanol/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / 15)
 
 /datum/reagent/ethanol/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustToxLoss(removed * 2 * toxicity)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -218,6 +218,7 @@
 	color = "#673910"
 	touch_met = 50
 	value = 6
+	fuel_value = 1.5
 
 /datum/reagent/thermite/touch_turf(var/turf/T)
 	if(volume >= 5)
@@ -227,10 +228,6 @@
 			W.overlays += image('icons/effects/effects.dmi',icon_state = "#673910")
 			remove_self(5)
 	return
-
-/datum/reagent/thermite/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / 5)
 
 /datum/reagent/thermite/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	M.adjustFireLoss(3 * removed)
@@ -242,14 +239,11 @@
 	reagent_state = LIQUID
 	color = "#673910"
 	touch_met = 50
+	fuel_value = 5
 
 /datum/reagent/napalm/touch_turf(var/turf/T)
 	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
 	remove_self(volume)
-
-/datum/reagent/napalm/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / 100)
 
 /datum/reagent/napalm/b
 	name = "Napalm B"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -107,17 +107,13 @@
 	color = "#ff3300"
 	strength = 30
 	touch_met = 5
-	var/fire_mult = 5
 	heating_point = null
 	heating_products = null
-
-/datum/reagent/toxin/phoron/touch_mob(var/mob/living/L, var/amount)
-	if(istype(L))
-		L.adjust_fire_stacks(amount / fire_mult)
+	fuel_value = 5
 
 /datum/reagent/toxin/phoron/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
 	M.take_organ_damage(0, removed * 0.1) //being splashed directly with phoron causes minor chemical burns
-	if(prob(10 * fire_mult))
+	if(prob(10 * fuel_value))
 		M.pl_effects()
 
 /datum/reagent/toxin/phoron/touch_turf(var/turf/simulated/T)
@@ -131,7 +127,7 @@
 	name = "Oxyphoron"
 	description = "An exceptionally flammable molecule formed from deuterium synthesis."
 	strength = 15
-	fire_mult = 15
+	fuel_value = 15
 
 /datum/reagent/toxin/phoron/oxygen/touch_turf(var/turf/simulated/T)
 	if(!istype(T))


### PR DESCRIPTION
- Reagents now have a `fuel_value` multiplier which determines how many fire stacks they add to targets and how good they are in a Molotov.
- Molotovs and rags can be lit with any flame source, not just `/flame` objects.
- Molotov fire exposure and ignition should be more reliable and intuitive. Hitting a mob or a tile should ignite everything in the turf.
- Molotovs will always smash on being thrown on harm intent, even if you miss your target.
- Fuel decals will now try to descend to the lowest available Z-level before burning.
- Alcohol is now properly flammable and smashing a bottle of vodka over someone's head will make them able to be ignited.

Closes #119.