### PR TITLE
Linux mapmerge.sh fix

### DIFF
--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -715,6 +715,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/item/wrench,
 /turf/simulated/floor/plating,
 /area/ship/scrap/shuttle/outgoing)
 "cB" = (

--- a/tools/mapmerge2/mapmerge.sh
+++ b/tools/mapmerge2/mapmerge.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export MAPROOT=../../maps/
 export TGM=1
-python mapmerge.py
+python3 mapmerge.py


### PR DESCRIPTION
Linux users have python installed on their system, but this is in reference to python2. Linux users should install python3 to run the script properly! Using python2 to do this would run into python errors, and it is not a good idea to overwrite the default python call in the event of unforeseen consequences with deprecated python functions.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->