### PR TITLE
Modifies mapmerge.sh script

### DIFF
--- a/tools/mapmerge2/mapmerge.sh
+++ b/tools/mapmerge2/mapmerge.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 export MAPROOT=../../maps/
 export TGM=1
-python mapmerge.py
+python3 mapmerge.py


### PR DESCRIPTION
Default Linux python calls python2. You don't want to override this! Install python3 to make it run properly.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->