### PR TITLE
Fix Enclave Patriarch access

### DIFF
--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -455,6 +455,7 @@
 	name = TRADESHIP_OUTFIT_JOB_NAME("Enclave Worker")
 	uniform = /obj/item/clothing/under/yinglet
 	shoes = /obj/item/clothing/shoes/sandal/yinglet
+	id_type = /obj/item/card/id
 	pda_type = /obj/item/modular_computer/pda
 	l_ear = null
 	r_ear = null

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -290,13 +290,14 @@
 	                    SKILL_ATMOS        = SKILL_MAX,
 	                    SKILL_ENGINES      = SKILL_MAX)
 	skill_points = 26
+	head_position = 1
 	department_flag = COM|CIV
 	access = list(
-		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge, 
+		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
 		access_hop, access_RC_announce, access_keycard_auth)
 	minimal_access = list(
-		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge, 
+		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
 		access_hop, access_RC_announce, access_keycard_auth)
 
@@ -323,11 +324,11 @@
 	selection_color = "#2f2f7f"
 	req_admin_notify = 1
 	access = list(
-		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge, 
+		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
 		access_hop, access_RC_announce, access_keycard_auth)
 	minimal_access = list(
-		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge, 
+		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
 		access_hop, access_RC_announce, access_keycard_auth)
 
@@ -454,7 +455,6 @@
 	name = TRADESHIP_OUTFIT_JOB_NAME("Enclave Worker")
 	uniform = /obj/item/clothing/under/yinglet
 	shoes = /obj/item/clothing/shoes/sandal/yinglet
-	id_type = /obj/item/card/id
 	pda_type = /obj/item/modular_computer/pda
 	l_ear = null
 	r_ear = null
@@ -467,6 +467,7 @@
 /decl/hierarchy/outfit/job/yinglet/patriarch
 	name = TRADESHIP_OUTFIT_JOB_NAME("Enclave Patriarch")
 	suit = /obj/item/clothing/suit/yinglet
+	id_type = /obj/item/card/id/silver
 	pda_type = /obj/item/modular_computer/pda/heads
 
 /decl/hierarchy/outfit/job/yinglet/matriarch


### PR DESCRIPTION
Enclave Patriarchs did not actually have any access. This seems to be because if the id_type field is missing or using /obj/item/card/id, it doesn't actually get any access!

This is fixed by setting the ID to type /obj/item/card/id/silver, same as the Enclave Matriarch.

The Enclave Patriarch was also moved to the 'head of staff' position for easy reference on the manifest.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->