### PR TITLE
Spelling error.

### DIFF
--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -102,7 +102,7 @@
 	alt_titles = list()
 
 /datum/job/doctor
-	title = "Docter"
+	title = "Doctor"
 	supervisors = "the Captain and your own ethics"
 	department_flag = COM|MED
 	department = "Ship's Crew"


### PR DESCRIPTION
Just fixed up Docter to Doctor.
I'm not having any issues playing as the Enclave roles on my machine, is there a server config file that might cause the issue?
To be clear the issue was that the Enclave roles were selectable in character setup but unavailable for actual game play. If you tried to spawn as one you got spawned in as a deck hand and if you tried to late join they would be missing from the selection menu.