### PR TITLE
Enclave Head access fixes

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -576,6 +576,18 @@ var/const/NO_EMAG_ACT = -50
 	desc = "A card which represents common sense and responsibility."
 	extra_details = list("goldstripe")
 
+/obj/item/card/id/civilian/head/yinglet/patriarch
+	name = "identification card"
+	desc = "A card which represents common sense and responsibility."
+	extra_details = list("goldstripe")
+	job_access_type = /datum/job/yinglet/patriarch
+
+/obj/item/card/id/civilian/head/yinglet/matriarch
+	name = "identification card"
+	desc = "A card which represents common sense and responsibility."
+	extra_details = list("goldstripe")
+	job_access_type = /datum/job/yinglet/matriarch
+
 /obj/item/card/id/merchant
 	name = "identification card"
 	desc = "A card issued to Merchants, indicating their right to sell and buy goods."

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -301,11 +301,11 @@
 	access = list(
 		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
-		access_hop, access_RC_announce, access_keycard_auth)
+		access_hop, access_RC_announce, access_keycard_auth, access_robotics, access_engine_equip)
 	minimal_access = list(
 		access_heads, access_medical, access_engine, access_change_ids, access_eva, access_bridge,
 		access_maint_tunnels, access_bar, access_janitor, access_cargo, access_cargo_bot, access_research, access_heads_vault,
-		access_hop, access_RC_announce, access_keycard_auth)
+		access_hop, access_RC_announce, access_keycard_auth, access_robotics, access_engine_equip)
 
 
 /datum/job/yinglet/matriarch
@@ -494,12 +494,12 @@
 /decl/hierarchy/outfit/job/yinglet/patriarch
 	name = TRADESHIP_OUTFIT_JOB_NAME("Enclave Patriarch")
 	suit = /obj/item/clothing/suit/yinglet
-	id_type = /obj/item/card/id/silver
+	id_type = /obj/item/card/id/civilian/head/yinglet/patriarch
 	pda_type = /obj/item/modular_computer/pda/heads
 
 /decl/hierarchy/outfit/job/yinglet/matriarch
 	name = TRADESHIP_OUTFIT_JOB_NAME("Enclave Matriarch")
 	uniform = /obj/item/clothing/under/yinglet/matriarch
 	head = /obj/item/clothing/head/yinglet/matriarch
-	id_type = /obj/item/card/id/silver
+	id_type = /obj/item/card/id/civilian/head/yinglet/matriarch
 	pda_type = /obj/item/modular_computer/pda/heads


### PR DESCRIPTION
Fixes #198 

This change makes three changes:

1. Patriarchs and Matriarchs were not actually getting the proper access list. This is resolved by creating unique ID instances for them. Running around the ship to test, I did not see any access that was lost.
2. Enclave Heads now have robotics access so they can use the exosuit fabricator/do maintenance on cyborgs.
3. Enclave Heads now have access_engine_equip so they can use the RobCo Tool Maker and the locked electrical closet.

Is this too much access for a role? Enclave Heads are basically captains without access to the captain's room.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->