### PR TITLE
Map and steal objective changes

### DIFF
--- a/code/game/objects/items/documents.dm
+++ b/code/game/objects/items/documents.dm
@@ -48,3 +48,13 @@
 	name = "private memos and faxes"
 	desc = "\"Top Secret\" memos and faxes between the SCGR and other officials of the SCG. It's like a chat client ran on pure paperwork."
 	description_antag = "The SCGR's conversations contain a massive amount of dirt on politicians: drugs, sex, money..."
+
+/obj/item/documents/tradehouse/account
+	name = "tradehouse accounting documents"
+	desc = "These contain exhaustive information about tradehouse dealings, with up-to-date information regarding wealth and resources controlled by the house."
+	description_antag = "In the wrong hands, the house could certainly find itself disavantaged in dealings in the future."
+
+/obj/item/documents/tradehouse/personnel
+	name = "tradehouse personnel data"
+	desc = "ValSalian interests are furthered by those who serve the house.  A good house must know all who work for it."
+	description_antag = "An enemy of the house could use this to figure out where personnel live and who among them might be a problem to them."

--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -3,7 +3,9 @@
 /turf/space,
 /area/space)
 "ad" = (
-/obj/machinery/door/unpowered/simple/wood,
+/obj/machinery/door/unpowered/simple/wood{
+	name = "matriarch's quarters"
+	},
 /turf/simulated/floor/wood/walnut,
 /area/ship/scrap/enclave)
 "ae" = (
@@ -1221,9 +1223,7 @@
 	flickering = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start{
-	name = "Enclave Patriarch"
-	},
+/obj/structure/flora/pottedplant/bamboo,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/enclave)
 "en" = (
@@ -1350,7 +1350,6 @@
 /turf/simulated/floor/plating,
 /area/ship/scrap/fore_starboard_underside_maint)
 "iY" = (
-/obj/structure/flora/pottedplant/bamboo,
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -1409,9 +1408,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/loading_bay)
-"mG" = (
-/turf/simulated/floor/wood/walnut,
-/area/ship/scrap/enclave)
 "oo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1494,12 +1490,10 @@
 /obj/item/storage/backpack/dufflebag,
 /obj/item/chems/glass/rag,
 /obj/item/chems/glass/bucket,
-/obj/item/clothing/head/yinglet/matriarch,
 /obj/item/clothing/shoes/sandal/yinglet,
 /obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
 /obj/item/clothing/suit/storage/toggle/redcoat/yinglet,
 /obj/item/clothing/suit/yinglet,
-/obj/item/clothing/under/yinglet/matriarch,
 /obj/machinery/firealarm{
 	pixel_y = 25
 	},
@@ -1557,8 +1551,12 @@
 	dir = 4
 	},
 /obj/machinery/disposal/deliveryChute{
+	dir = 8;
 	icon_state = "intake";
-	dir = 8
+	name = "disposals ejection chute"
+	},
+/obj/structure/sign/warning/deathsposal{
+	pixel_y = -32
 	},
 /turf/simulated/floor,
 /area/ship/scrap/loading_bay)
@@ -1877,6 +1875,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
 /obj/structure/curtain/open/bed,
+/obj/item/clothing/under/yinglet/matriarch,
+/obj/item/clothing/head/yinglet/matriarch,
 /turf/simulated/floor/wood/walnut,
 /area/ship/scrap/enclave)
 "LI" = (
@@ -5255,7 +5255,7 @@ aa
 fY
 en
 ae
-mG
+ZL
 ax
 pU
 zi

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -126,6 +126,10 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
 "ay" = (
@@ -265,13 +269,17 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/robot)
 "aR" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/handrai{
 	tag = "icon-handrail (EAST)";
 	icon_state = "handrail";
 	dir = 4
 	},
 /obj/machinery/mining/brace,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/cargo/lower)
 "aS" = (
@@ -442,6 +450,7 @@
 	icon_state = "handrail";
 	dir = 8
 	},
+/obj/structure/ore_box,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/cargo/lower)
 "bi" = (
@@ -707,6 +716,10 @@
 /obj/item/bodybag,
 /obj/item/stack/tile/carpet/fifty,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/cargo/lower)
 "bK" = (
@@ -2302,7 +2315,7 @@
 /area/ship/scrap/maintenance/storage)
 "fb" = (
 /obj/machinery/light,
-/obj/machinery/suit_storage_unit/engineering/salvage,
+/obj/machinery/suit_cycler/tradeship,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/scrap/maintenance/eva)
 "fc" = (
@@ -2311,7 +2324,7 @@
 	icon_state = "alarm0";
 	pixel_x = 24
 	},
-/obj/machinery/suit_storage_unit/engineering/salvage,
+/obj/machinery/suit_cycler/tradeship,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/scrap/maintenance/eva)
 "fd" = (
@@ -2415,7 +2428,7 @@
 	icon_state = "conveyor0";
 	id = "con"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "hp" = (
 /obj/machinery/door/firedoor,
@@ -2472,6 +2485,13 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/scrap/escape_port)
+"js" = (
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/cargo/lower)
 "jD" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
@@ -2486,7 +2506,7 @@
 	input_turf = 2;
 	output_turf = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "kb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -2724,7 +2744,7 @@
 "tz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "ub" = (
 /obj/item/stool/padded,
@@ -2925,19 +2945,27 @@
 	id = "con";
 	movedir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "BO" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/dorms3)
+"Cr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 9
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/cargo/lower)
 "CN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/loading{
 	icon_state = "loadingarea";
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "Db" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3051,6 +3079,10 @@
 /area/ship/scrap/cargo/lower)
 "HH" = (
 /obj/structure/ladder/up,
+/obj/effect/floor_decal/corner/beige{
+	icon_state = "corner_white";
+	dir = 6
+	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
 "Ib" = (
@@ -3079,7 +3111,7 @@
 	icon_state = "conveyor1";
 	id = "con"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "Jb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3248,7 +3280,7 @@
 	input_turf = 1;
 	output_turf = 2
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "Rq" = (
 /obj/effect/paint/brown,
@@ -3339,7 +3371,7 @@
 "WT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "WZ" = (
 /obj/effect/paint/brown,
@@ -6417,8 +6449,8 @@ pr
 al
 al
 aF
-aU
-du
+js
+Cr
 aR
 bd
 bt

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -5691,6 +5691,8 @@
 	name = "External Lockdown"
 	},
 /obj/random_multi/single_item/captains_spare_id,
+/obj/item/documents/tradehouse/account,
+/obj/item/documents/tradehouse/personnel,
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/command/bridge)
 "CD" = (
@@ -6121,16 +6123,14 @@
 	pixel_x = 32
 	},
 /obj/random/voidhelmet,
-/obj/random/voidhelmet,
-/obj/random/voidhelmet,
-/obj/random/voidsuit,
-/obj/random/voidsuit,
 /obj/random/voidsuit,
 /obj/structure/handrai{
 	tag = "icon-handrail (WEST)";
 	icon_state = "handrail";
 	dir = 8
 	},
+/obj/random/voidhelmet,
+/obj/random/voidsuit,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/saloon)
 "Jp" = (

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -17,10 +17,6 @@
 /obj/structure/lattice,
 /turf/space,
 /area/space)
-"ad" = (
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless,
-/area/space)
 "ae" = (
 /turf/simulated/floor/airless,
 /area/space)
@@ -117,11 +113,6 @@
 	icon_state = "coil2"
 	},
 /turf/simulated/floor/airless,
-/area/space)
-"ar" = (
-/obj/item/solar_assembly,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless,
 /area/space)
 "as" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -271,8 +262,7 @@
 	icon_state = "0-4"
 	},
 /obj/item/solar_assembly,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/space)
 "aJ" = (
 /obj/structure/cable/yellow{
@@ -356,8 +346,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/space)
 "aT" = (
 /obj/structure/cable/yellow{
@@ -365,8 +354,7 @@
 	icon_state = "0-8"
 	},
 /obj/item/solar_assembly,
-/obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/airless,
 /area/space)
 "aU" = (
 /obj/structure/cable/yellow{
@@ -456,15 +444,6 @@
 /obj/item/stack/material/glass/ten,
 /turf/simulated/floor/airless,
 /area/space)
-"be" = (
-/obj/structure/handrai{
-	tag = "icon-handrail (NORTH)";
-	icon_state = "handrail";
-	dir = 1
-	},
-/obj/item/wrench,
-/turf/simulated/floor/reinforced/airless,
-/area/space)
 "bf" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
@@ -493,6 +472,10 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/airless,
+/area/space)
+"tg" = (
+/obj/item/wrench,
+/turf/simulated/floor/reinforced/airless,
 /area/space)
 
 (1,1,1) = {"
@@ -3899,13 +3882,13 @@ ax
 ax
 ae
 ae
-ad
-ad
-ad
+ae
+ae
+ae
 aI
 aS
 aZ
-be
+an
 aV
 au
 aV
@@ -4061,11 +4044,11 @@ ax
 ax
 ax
 ax
-ad
-ad
 ae
-ad
-ar
+ae
+ae
+ae
+ay
 ae
 aW
 aZ
@@ -4312,7 +4295,7 @@ ax
 ax
 ax
 ax
-ax
+tg
 ax
 ax
 ax

--- a/maps/tradeship/tradeship_define.dm
+++ b/maps/tradeship/tradeship_define.dm
@@ -40,6 +40,18 @@
 
 	radiation_detected_message = "High levels of radiation have been detected in proximity of the %STATION_NAME%. Please move to a shielded area such as the cargo bay, dormitories or medbay until the radiation has passed."
 	
+	potential_theft_targets = list(
+		"the tradehouse accounting documents"	= /obj/item/documents/tradehouse/account,
+		"the tradehouse personnel data"			= /obj/item/documents/tradehouse/personnel,
+		"the Captain's spare ID"				= /obj/item/card/id/captains_spare,
+		"the ship's blueprints"					= /obj/item/blueprints,
+		"the Matriarch's robes"					= /obj/item/clothing/under/yinglet/matriarch,
+		"a jetpack"								= /obj/item/tank/jetpack/,
+		"a pump action shotgun"					= /obj/item/gun/projectile/shotgun/pump/,
+		"a health analyzer"						= /obj/item/scanner/health,
+		"the integrated circuit printer"		= /obj/item/integrated_circuit_printer,
+		"a whole uneaten mollusc"				= /obj/item/mollusc
+	)
 
 /datum/map/tradeship/get_map_info()
 	return "You're aboard the <b>[station_name],</b> a survey and mercantile vessel affiliated with <b>Tradehouse Ivenmoth</b>, a large merchant guild operating out of Val Salia Station. \


### PR DESCRIPTION
* Re-added orebox to lower cargo
* Tidied up some decals in lower cargo
* Removed some pointless tiled turf from solar arrays
* Added new secret documents to bridge (Thanks @ZirconiumWit for flavour text)
* Replaced suit storage units with suit cyclers
* Moved potted bamboo plant in enclave chamber
* Renamed delivery chute to disposal ejection chute
* Added a warning sign to disposal ejection chute
* Changes tradeships steal objectives entirely

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->