### PR TITLE
Adding some hints to the slapcrafting system.

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -22,8 +22,8 @@
 /obj/item/melee/baton/loaded
 	bcell = /obj/item/cell/device/high
 
-/obj/item/melee/baton/Initialize()
-	. = ..()
+/obj/item/melee/baton/Initialize(var/ml)
+	. = ..(ml)
 	if(ispath(bcell))
 		bcell = new bcell(src)
 		update_icon()

--- a/code/modules/crafting/_crafting_holder.dm
+++ b/code/modules/crafting/_crafting_holder.dm
@@ -2,6 +2,30 @@
 	var/decl/crafting_stage/current_crafting_stage
 	var/label_name
 
+/obj/item/crafting_holder/examine(mob/user, distance)
+	. = ..()
+	if(current_crafting_stage)
+		var/list/next_steps = list()
+		var/list/next_products = list()
+		for(var/decl/crafting_stage/next_stage in current_crafting_stage.next_stages)
+			if(ispath(next_stage.completion_trigger_type))
+				var/atom/next_tool = next_stage.completion_trigger_type
+				var/tool_string = initial(next_tool.name)
+				if(next_stage.stack_consume_amount > 1)
+					tool_string = "[next_stage.stack_consume_amount] [tool_string]\s"
+				else
+					tool_string = "\a [tool_string]"
+				if(ispath(next_stage.product))
+					var/atom/next_product = next_stage.product
+					next_products[tool_string] = "\a [initial(next_product.name)]"
+				else
+					next_steps += tool_string
+		if(length(next_products))
+			for(var/thing in next_products)
+				to_chat(user, SPAN_NOTICE("With <b>[thing]</b>, you could finish building <b>[next_products[thing]]</b>."))
+		if(length(next_steps))
+			to_chat(user, SPAN_NOTICE("You could continue to work on this with <b>[english_list(next_steps, and_text = " or ")]</b>."))
+
 /obj/item/crafting_holder/Initialize(var/ml, var/decl/crafting_stage/initial_stage, var/obj/item/target, var/obj/item/tool, var/mob/user)
 	. = ..()
 	name = "[target.name] assembly"

--- a/code/modules/crafting/_crafting_stage.dm
+++ b/code/modules/crafting/_crafting_stage.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage
+	var/descriptor = "undefined crafted item"
 	var/item_desc = "It's an unfinished item of some sort."
 	var/item_icon = 'icons/obj/crafting_icons.dmi'
 	var/item_icon_state = "default"

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_ed209.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_ed209.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/material/ed209_start
+	descriptor = "security walker"
 	stack_consume_amount = 5
 	stack_material = MATERIAL_STEEL
 	begins_with_object_type = /obj/item/robot_parts/robot_suit

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_farmbot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_farmbot.dm
@@ -14,6 +14,7 @@
 	tank.forceMove(src)
 
 /decl/crafting_stage/farmbot_begin
+	descriptor = "farm bot"
 	progress_message = "You attach a plant scanner to the water tank."
 	begins_with_object_type = /obj/item/farmbot_arm_assembly
 	completion_trigger_type = /obj/item/scanner/plant

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_floorbot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_floorbot.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/empty_storage/floorbot
+	descriptor = "floor bot"
 	stack_consume_amount = 10
 	begins_with_object_type = /obj/item/storage/toolbox
 	completion_trigger_type = /obj/item/stack/tile

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_janibot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_janibot.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/proximity/janibot
+	descriptor = "janitor bot"
 	begins_with_object_type = /obj/item/chems/glass/bucket
 	progress_message = "You put the proximity sensor into the bucket."
 	item_icon_state = "janibot_1"

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_medibot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_medibot.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/empty_storage/medibot
+	descriptor = "medical bot"
 	begins_with_object_type = /obj/item/storage/firstaid
 	progress_message = "You add the robot arm to the first aid kit."
 	completion_trigger_type = /obj/item/robot_parts

--- a/code/modules/crafting/crafting_recipes/bot_crafting/crafting_secbot.dm
+++ b/code/modules/crafting/crafting_recipes/bot_crafting/crafting_secbot.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/secbot_signaller
+	descriptor = "security bot"
 	begins_with_object_type = /obj/item/clothing/head/helmet
 	completion_trigger_type = /obj/item/assembly/signaler
 	progress_message = "You add the signaler to the helmet."

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_cannon.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_cannon.dm
@@ -6,6 +6,7 @@
 	item_state = "pneumatic"
 
 /decl/crafting_stage/pipe/cannon
+	descriptor = "pneumatic cannon"
 	item_desc = "It is a half-finished pneumatic cannon with a pipe segment installed."
 	progress_message = "You secure the piping inside the frame."
 	next_stages = list(/decl/crafting_stage/welding/cannon_pipe)

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_coilgun.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_coilgun.dm
@@ -6,6 +6,7 @@
 	icon_state = "coilgun_construction_1"
 
 /decl/crafting_stage/material/coilgun_body
+	descriptor = "coilgun"
 	begins_with_object_type = /obj/item/coilgun_assembly
 	item_desc = "It's a half-built coilgun with a metal frame loosely shaped around the stock."
 	progress_message = "You shape some steel sheets around the stock to form a body."

--- a/code/modules/crafting/crafting_recipes/gun_crafting/crafting_zipgun.dm
+++ b/code/modules/crafting/crafting_recipes/gun_crafting/crafting_zipgun.dm
@@ -6,6 +6,7 @@
 	item_state = "zipgun-solid"
 
 /decl/crafting_stage/pipe/zipgun
+	descriptor = "zipgun"
 	begins_with_object_type = /obj/item/zipgunframe
 	item_desc = "A half-built zipgun with a barrel loosely fitted to the stock."
 	item_icon_state = "zipgun1"

--- a/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_butterflyknife.dm
+++ b/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_butterflyknife.dm
@@ -15,6 +15,7 @@
 	thrown_material_force_multiplier = 0.1
 
 /decl/crafting_stage/balisong_blade
+	descriptor = "balisong"
 	begins_with_object_type = /obj/item/material/butterflyhandle
 	item_desc = "It's an unfinished balisong with some loose screws."
 	item_icon_state = "butterfly"

--- a/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_crossbow.dm
+++ b/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_crossbow.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/crafting_icons.dmi'
 
 /decl/crafting_stage/material/crossbow_rods
+	descriptor = "crossbow"
 	begins_with_object_type = /obj/item/crossbowframe
 	completion_trigger_type = /obj/item/stack/material/rods
 	stack_consume_amount = 3

--- a/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_spear_prod.dm
+++ b/code/modules/crafting/crafting_recipes/improvised_crafting/crafting_spear_prod.dm
@@ -1,4 +1,5 @@
 /decl/crafting_stage/material/stunprod_rod
+	descriptor = "spear or stunprod"
 	begins_with_object_type = /obj/item/handcuffs/cable
 	item_icon_state = "wiredrod"
 	progress_message = "You wind the cable cuffs around the top of the steel rod."


### PR DESCRIPTION
- Examining an in-progress build will show you possible options or products.
- Examining a source item will suggest how you can start a build.
- Order of initial components no longer matters.

No codex entry for recipes yet, and no skill checks in crafting. Still thinking about how it should work.
Related to #244.