### PR TITLE
Fixes sound_env and ambience issues with turbolifts on Tradeship.

### DIFF
--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -217,7 +217,9 @@
 	icon_state = "shuttle"
 	requires_power = 0
 	dynamic_lighting = 1
+	sound_env = STANDARD_STATION
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED
+	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambigen12.ogg')
 	arrival_sound = null
 	lift_announce_str = null
 


### PR DESCRIPTION
The background hum is part of the atmos code and isn't a bug - there are no vents in the elevator area, so it doesn't play the hum. Really that should be based on the air zone you're, but that's a rewrite/feature request rather than a fix.

Closes #248.