### PR TITLE
Optimization to radio components.

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
+++ b/code/game/machinery/_machines_base/stock_parts/radio/transmitter.dm
@@ -2,7 +2,7 @@
 	name = "radio transmitter"
 	desc = "A radio transmitter designed for use with machines."
 	icon_state = "subspace_transmitter"
-	var/range       // If you want range-limited subtypes
+	var/range = 60  // Limits transmit range
 	var/latency = 2 // Delay between event and transmission; doesn't apply to transmit on tick
 	var/buffer
 


### PR DESCRIPTION
The reason this is an optimization is that without range set, _all_ potential listeners, regardless of loc, will attempt to receive the signals.

This version has a high enough setting to work with all away maps on alarms; can't be lowered without subtyping off long-distance versions or making map changes (there are exactly two alarms that need to go above 22, which is sort of the default, so the latter is viable). No guarantee that it won't break some buttons.