### PR TITLE
Tradeship map changes, mostly

### DIFF
--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -2134,6 +2134,7 @@
 /obj/structure/closet/crate,
 /obj/item/clothing/accessory/medal/gold,
 /obj/item/clothing/accessory/locket,
+/obj/random_multi/single_item/captains_spare_id,
 /turf/simulated/floor,
 /area/ship/scrap/aft_starboard_underside_maint)
 "Zz" = (

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -676,6 +676,7 @@
 "bD" = (
 /obj/structure/table/standard,
 /obj/random/masks,
+/obj/random_multi/single_item/captains_spare_id,
 /turf/simulated/floor/lino,
 /area/ship/scrap/crew/dorms1)
 "bE" = (

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -61,14 +61,21 @@
 /area/ship/scrap/shuttle/outgoing)
 "aw" = (
 /turf/simulated/wall/r_wall,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "aD" = (
-/obj/machinery/ntnet_relay,
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
-"aE" = (
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
+/obj/structure/table/standard,
+/obj/item/paper_bin,
+/obj/item/pen/multi,
+/obj/structure/filingcabinet/wallcabinet{
+	pixel_x = 1;
+	pixel_y = 28
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/item/material/clipboard,
+/turf/simulated/floor/carpet,
+/area/ship/scrap/command/fmate)
 "aI" = (
 /obj/item/bedsheet/captain,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -97,11 +104,12 @@
 /turf/simulated/wall/titanium,
 /area/ship/scrap/shuttle/outgoing)
 "aP" = (
-/obj/machinery/message_server,
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
+/obj/structure/table/standard,
+/obj/item/megaphone,
+/obj/machinery/cell_charger,
+/turf/simulated/floor/carpet,
+/area/ship/scrap/command/fmate)
 "aQ" = (
-/obj/machinery/door/window/westleft,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -113,8 +121,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/scrap/comms)
+/turf/simulated/floor/wood,
+/area/ship/scrap/command/fmate)
 "aS" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -165,11 +173,12 @@
 	pixel_x = 0;
 	pixel_y = -32
 	},
-/obj/machinery/computer/message_monitor{
+/obj/machinery/computer/modular/preset/cardslot/command{
+	icon_state = "computer";
 	dir = 4
 	},
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
+/turf/simulated/floor/carpet,
+/area/ship/scrap/command/fmate)
 "bb" = (
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -325,9 +334,7 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -35
 	},
-/obj/machinery/computer/shuttle_control/explore/tradeship{
-	dir = 4
-	},
+/obj/machinery/computer/shuttle_control/explore/tradeship,
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/dock)
 "bC" = (
@@ -3653,6 +3660,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/mob/living/simple_animal/opossum/poppy,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/scrap/maintenance/engineering)
 "iB" = (
@@ -4883,7 +4891,7 @@
 "oK" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "pb" = (
 /obj/item/radio/intercom{
 	pixel_y = 22
@@ -5024,7 +5032,7 @@
 	id_tag = "sensor"
 	},
 /turf/simulated/floor/airless,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "ra" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -5074,7 +5082,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/plating,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "rv" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/industrial/warning,
@@ -5128,6 +5136,19 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/structure/ladder/up,
+/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up/supply{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/dock)
 "sf" = (
@@ -5171,6 +5192,18 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/hidden)
+"sM" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/space)
 "sS" = (
 /turf/simulated/floor/plating,
 /area/ship/scrap/hidden)
@@ -5200,6 +5233,9 @@
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/dock)
+"tg" = (
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/dock)
 "tJ" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "scram"
@@ -5220,7 +5256,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor/airless,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "uc" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -5305,8 +5341,6 @@
 /obj/item/gun/energy/stunrevolver,
 /obj/structure/closet/cabinet,
 /obj/item/storage/secure/briefcase,
-/obj/item/taperecorder,
-/obj/item/camera,
 /obj/item/storage/backpack/dufflebag/syndie,
 /obj/item/storage/box/ammo/shotgunshells,
 /obj/item/handcuffs,
@@ -5314,6 +5348,8 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
+/obj/item/clothing/head/powdered_wig,
+/obj/item/clothing/suit/judgerobe,
 /turf/simulated/floor/wood,
 /area/ship/scrap/command/captain)
 "vS" = (
@@ -5453,9 +5489,8 @@
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/engine/aft)
 "xS" = (
-/obj/machinery/r_n_d/server/core,
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
+/turf/simulated/floor/carpet,
+/area/ship/scrap/command/fmate)
 "xZ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4;
@@ -5527,7 +5562,7 @@
 "zs" = (
 /obj/machinery/shipsensors,
 /turf/simulated/floor/airless,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "zO" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
@@ -5642,6 +5677,14 @@
 /obj/item/clamp,
 /turf/simulated/floor/tiled/techfloor,
 /area/ship/scrap/maintenance/atmos)
+"BZ" = (
+/obj/structure/table/marble,
+/obj/machinery/door/window/brigdoor/southright,
+/obj/machinery/door/blast/shutters{
+	id_tag = "fmate"
+	},
+/turf/simulated/floor/wood,
+/area/ship/scrap/command/fmate)
 "Cb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -5796,11 +5839,24 @@
 	pixel_x = 24;
 	pixel_y = 0
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/handcuffs,
+/obj/item/melee/telebaton,
+/obj/item/gun/energy/stunrevolver/rifle,
+/obj/structure/closet/secure_closet{
+	req_access = list("ACCESS_HEAD_OF_PERSONNEL")
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/scrap/comms)
+/obj/item/clothing/suit/armor/vest,
+/obj/item/storage/box/ids,
+/obj/item/flash,
+/obj/item/clothing/glasses/sunglasses,
+/obj/item/storage/box/evidence,
+/obj/item/taperoll/police,
+/obj/item/holowarrant,
+/obj/item/storage/briefcase/crimekit,
+/obj/item/taperecorder,
+/obj/item/camera,
+/turf/simulated/floor/wood,
+/area/ship/scrap/command/fmate)
 "Ec" = (
 /obj/structure/closet/crate,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5832,6 +5888,27 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/medbay)
+"EA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_y = 0
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/dock)
 "EQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5847,7 +5924,7 @@
 	},
 /obj/machinery/door/airlock/hatch/autoname/command,
 /turf/simulated/floor/tiled/dark,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "Fc" = (
 /obj/machinery/light{
 	icon_state = "bulb1";
@@ -5875,7 +5952,7 @@
 	},
 /obj/effect/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "FS" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -6105,6 +6182,18 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/command/hallway)
+"Jk" = (
+/obj/structure/bed/chair/office/dark,
+/obj/machinery/button/blast_door{
+	id_tag = "fmate";
+	pixel_x = 25;
+	pixel_y = -2
+	},
+/obj/effect/landmark/start{
+	name = "First Mate"
+	},
+/turf/simulated/floor/wood,
+/area/ship/scrap/command/fmate)
 "Jn" = (
 /obj/effect/floor_decal/corner/beige{
 	icon_state = "corner_white";
@@ -6311,7 +6400,7 @@
 "Ls" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall/hull,
-/area/ship/scrap/comms)
+/area/ship/scrap/command/fmate)
 "Lx" = (
 /obj/structure/handrai{
 	tag = "icon-handrail (WEST)";
@@ -6468,11 +6557,12 @@
 	dir = 1;
 	pixel_y = -30
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/ship/scrap/comms)
+/obj/structure/dogbed,
+/obj/item/clothing/shoes/brown,
+/obj/random/plushie,
+/mob/living/simple_animal/corgi/Ian,
+/turf/simulated/floor/wood,
+/area/ship/scrap/command/fmate)
 "Oc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	icon_state = "intact";
@@ -6492,9 +6582,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/sign/warning/server_room{
-	pixel_x = -32
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -10078,9 +10165,9 @@ aw
 aD
 aP
 ba
-oK
-aa
-bA
+aw
+sM
+bm
 bB
 bQ
 ch
@@ -10158,11 +10245,11 @@ qT
 zs
 FD
 xS
-aE
-aE
-FD
-aa
-bA
+xS
+xS
+Jk
+BZ
+tg
 bC
 qc
 uc
@@ -10491,7 +10578,7 @@ as
 as
 bm
 bw
-bE
+EA
 sc
 Mw
 FS

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -178,6 +178,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"aN" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/comms)
 "aR" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -246,12 +259,43 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"bE" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
+"cB" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
+"cO" = (
+/obj/structure/grille/broken,
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "dq" = (
 /obj/structure/cable/yellow{
 	icon_state = "6-9"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"ds" = (
+/obj/machinery/ntnet_relay,
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
+"fi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
 "gb" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing0-1";
@@ -268,6 +312,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"gw" = (
+/obj/item/caution/cone,
+/obj/structure/cable{
+	icon_state = "1-8";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "gx" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/warning,
@@ -293,6 +352,19 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"jv" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "jy" = (
 /obj/machinery/constructable_frame/computerframe{
 	icon_state = "unwired";
@@ -304,6 +376,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"jz" = (
+/turf/simulated/wall/r_wall,
+/area/ship/scrap/comms)
+"jJ" = (
+/obj/machinery/door/airlock/hatch/autoname/command,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8";
+	pixel_x = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/comms)
 "kF" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -318,6 +410,9 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"kL" = (
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/command/bridge_upper)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -340,6 +435,41 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"ne" = (
+/turf/simulated/wall/r_wall,
+/area/ship/scrap/bridge_unused)
+"nZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
+"oq" = (
+/obj/random/trash,
+/obj/machinery/power/apc{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d1 = 1;
+	d2 = 4
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "oE" = (
 /obj/machinery/light/small{
 	icon_state = "bulb_map";
@@ -347,6 +477,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"oY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "pC" = (
 /obj/item/wrench,
 /obj/structure/handrai{
@@ -362,6 +504,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"rl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
 "sx" = (
 /obj/structure/railing/mapped{
 	icon_state = "railing0-1";
@@ -381,6 +536,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"sX" = (
+/obj/machinery/door/window/westleft,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/comms)
+"tJ" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/scrap/command/bridge_upper)
 "uM" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "solars_in"
@@ -391,6 +565,16 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/scrap/maintenance/solars)
+"uT" = (
+/obj/random/shoes,
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "vi" = (
 /obj/structure/handrai{
 	tag = "icon-handrail (WEST)";
@@ -403,12 +587,34 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"wc" = (
+/obj/effect/floor_decal/steeldecal/steel_decals6,
+/obj/machinery/power/apc{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1;
+	d2 = 2
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
 "wf" = (
 /obj/structure/cable/yellow{
 	icon_state = "6-8"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"wq" = (
+/obj/item/stack/material/rods,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "xe" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -434,6 +640,25 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/scrap/maintenance/solars)
+"yA" = (
+/obj/machinery/alarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -30
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/comms)
 "yQ" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "solars_sensor";
@@ -453,6 +678,15 @@
 	},
 /turf/simulated/open,
 /area/ship/scrap/maintenance/solars)
+"zn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "zH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -464,6 +698,10 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"zY" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/scrap/bridge_unused)
 "Al" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning";
@@ -483,12 +721,52 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"Db" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/airless,
+/area/ship/scrap/bridge_unused)
+"Dr" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ship/scrap/comms)
 "DP" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-5"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"DY" = (
+/obj/machinery/door/airlock/hatch/autoname/command,
+/obj/structure/cable{
+	icon_state = "4-8";
+	d1 = 1;
+	d2 = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/item/taperoll/engineering/applied,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/bridge_unused)
 "DZ" = (
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/scrap/maintenance/solars)
@@ -543,6 +821,12 @@
 	},
 /turf/space,
 /area/ship/scrap/maintenance/solars)
+"HN" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
 "IY" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -556,6 +840,24 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/open,
 /area/ship/scrap/maintenance/solars)
+"Jm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/command/bridge_upper)
+"Jo" = (
+/obj/machinery/message_server,
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
 "Ko" = (
 /obj/structure/catwalk,
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -574,6 +876,27 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"KK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/light_switch{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/command/bridge_upper)
+"KS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1;
+	level = 2
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "Lf" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	icon_state = "warningcorner";
@@ -607,6 +930,34 @@
 	},
 /turf/simulated/open,
 /area/ship/scrap/maintenance/solars)
+"MD" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/ship/scrap/command/bridge_upper)
+"Nc" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/airless,
+/area/ship/scrap/command/bridge_upper)
+"Ob" = (
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall/hull,
+/area/ship/scrap/comms)
 "Oy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-10"
@@ -630,6 +981,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"PZ" = (
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
+"QK" = (
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor/airless,
+/area/ship/scrap/comms)
 "Rg" = (
 /obj/structure/cable/yellow,
 /turf/simulated/floor/airless,
@@ -645,6 +1010,20 @@
 	},
 /turf/space,
 /area/ship/scrap/maintenance/solars)
+"RZ" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4;
+	level = 2
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/machinery/alarm{
+	pixel_y = 17
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
 "Sc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -661,6 +1040,30 @@
 	},
 /turf/simulated/floor/airless,
 /area/space)
+"Su" = (
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
+"SC" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	tag = "icon-map-scrubbers (NORTH)";
+	icon_state = "map-scrubbers";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/command/bridge_upper)
 "SO" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -673,6 +1076,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"SQ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/wallframe_spawn/reinforced,
+/turf/simulated/floor/plating,
+/area/ship/scrap/command/bridge_upper)
 "Tt" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -681,6 +1096,10 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"Tx" = (
+/obj/machinery/r_n_d/server/core,
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
 "Ua" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -729,6 +1148,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)
+"Xb" = (
+/turf/simulated/wall/r_wall,
+/area/ship/scrap/command/bridge_upper)
 "Xu" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -742,6 +1164,10 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"XF" = (
+/obj/random/trash,
+/turf/simulated/floor/plating,
+/area/ship/scrap/bridge_unused)
 "XQ" = (
 /obj/machinery/door/airlock/multi_tile/engineering,
 /obj/machinery/door/firedoor,
@@ -765,6 +1191,19 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"YA" = (
+/obj/machinery/door/airlock/hatch/autoname/command,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2";
+	pixel_y = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/command/bridge_upper)
 "Zx" = (
 /obj/structure/handrai{
 	tag = "icon-handrail (EAST)";
@@ -773,6 +1212,66 @@
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/space)
+"ZD" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Communications APC"
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	d2 = 2
+	},
+/obj/machinery/light_switch{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/ship/scrap/comms)
+"ZT" = (
+/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/zpipe/down/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/down/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 32;
+	d2 = 1;
+	icon_state = "32-1"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/monotile,
+/area/ship/scrap/command/bridge_upper)
+"ZU" = (
+/obj/machinery/alarm{
+	dir = 1;
+	icon_state = "alarm0";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/computer/message_monitor{
+	dir = 4
+	},
+/turf/simulated/floor/bluegrid,
+/area/ship/scrap/comms)
 
 (1,1,1) = {"
 aa
@@ -3499,10 +3998,10 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
+Ob
+Ob
+QK
+Ob
 ax
 aa
 ax
@@ -3580,12 +4079,12 @@ aa
 aa
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+Ob
+jz
+jz
+aN
+jz
+Ob
 ac
 ax
 ax
@@ -3662,12 +4161,12 @@ aa
 aa
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+Ob
+jz
+ds
+Jo
+ZU
+Ob
 ac
 ax
 ax
@@ -3744,12 +4243,12 @@ aa
 aa
 aa
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+Ob
+jz
+Tx
+Su
+Su
+Dr
 ac
 ax
 ax
@@ -3826,17 +4325,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+Ob
+jz
+ZD
+sX
+yA
+Ob
+tJ
+tJ
+SQ
+tJ
+tJ
 ax
 aa
 aa
@@ -3908,17 +4407,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+Ob
+jz
+jz
+jJ
+jz
+jz
+Xb
+RZ
+HN
+bE
+SQ
 ax
 ax
 ax
@@ -3990,17 +4489,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+Nc
+MD
+kL
+SC
+Jm
+KK
+YA
+rl
+fi
+PZ
+SQ
 ax
 ax
 ax
@@ -4072,17 +4571,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+zY
+ne
+ne
+DY
+ne
+ne
+Xb
+wc
+nZ
+ZT
+SQ
 ax
 ax
 ax
@@ -4154,17 +4653,17 @@ ax
 ax
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
-ax
+zY
+ne
+oq
+gw
+uT
+zY
+tJ
+tJ
+SQ
+tJ
+tJ
 ax
 aa
 aa
@@ -4236,12 +4735,12 @@ aa
 aa
 aa
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+zY
+ne
+wq
+zn
+KS
+oY
 aa
 ax
 ax
@@ -4318,12 +4817,12 @@ aa
 aa
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+zY
+cB
+cO
+XF
+XF
+zY
 ac
 ax
 ax
@@ -4400,12 +4899,12 @@ aa
 aa
 ax
 ax
-ax
-ax
-ax
-ax
-ax
-ax
+zY
+ne
+ne
+jv
+cB
+zY
 ac
 ax
 ax
@@ -4483,10 +4982,10 @@ aa
 aa
 aa
 aa
-ax
-ax
-ax
-ax
+zY
+zY
+Db
+zY
 ax
 aa
 ax

--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -186,10 +186,24 @@
 	icon_state = "captain"
 	req_access = list(access_captain)
 
+/area/ship/scrap/command/fmate
+	name = "\improper First Mate's Office"
+	icon_state = "heads_hop"
+	req_access = list(access_hop)
+
+/area/ship/scrap/command/bridge_upper
+	name = "\improper Upper Bridge"
+	icon_state = "blue"
+	req_access = list(access_heads)
+
 /area/ship/scrap/comms
 	name = "\improper Communications Relay"
 	icon_state = "tcomsatcham"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/signal.ogg','sound/ambience/sonar.ogg')
+
+/area/ship/scrap/bridge_unused
+	name = "\improper Bridge Starboard Storage"
+	icon_state = "armory"
 
 /area/ship/scrap/shuttle
 	area_flags = AREA_FLAG_RAD_SHIELDED

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -154,7 +154,7 @@
 
 	max_skill = list(   SKILL_PILOT       = SKILL_MAX,
 	                    SKILL_FINANCE     = SKILL_MAX,
-	                    SKILL_BUREAUCRACY = SKILL_ADEPT)
+	                    SKILL_BUREAUCRACY = SKILL_EXPERT)
 	skill_points = 30
 	alt_titles = list()
 


### PR DESCRIPTION
* Two new spawn points for captain spare ID. One on enclave deck and one in a dorm
* Added upper bridge area
* Moved comms to upper bridge
* Added First Mate office to lower bridge, with things in it i dunno go look at it
* Added Poppy to Engineering *Hot Feature*
* Increased First mate paperwork skill one level

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->