### PR TITLE
Removes the concept of area master alarm.

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -43,7 +43,6 @@
 
 //all air alarms in area are connected via magic
 /area
-	var/obj/machinery/alarm/master_air_alarm
 	var/list/air_vent_names = list()
 	var/list/air_scrub_names = list()
 	var/list/air_vent_info = list()
@@ -128,9 +127,6 @@
 
 /obj/machinery/alarm/Destroy()
 	unregister_radio(src, frequency)
-	if(alarm_area && alarm_area.master_air_alarm == src)
-		alarm_area.master_air_alarm = null
-		elect_master(exclude_self = TRUE)
 	return ..()
 
 /obj/machinery/alarm/Initialize(mapload, var/dir, atom/frame)
@@ -163,8 +159,6 @@
 			trace_gas += g
 
 	set_frequency(frequency)
-	if (!master_is_operating())
-		elect_master()
 	update_icon()
 
 /obj/machinery/alarm/get_req_access()
@@ -303,20 +297,6 @@
 
 	return 0
 
-
-/obj/machinery/alarm/proc/master_is_operating()
-	return alarm_area.master_air_alarm && !(alarm_area.master_air_alarm.stat & (NOPOWER|BROKEN))
-
-
-/obj/machinery/alarm/proc/elect_master(exclude_self = FALSE)
-	for (var/obj/machinery/alarm/AA in alarm_area)
-		if(exclude_self && AA == src)
-			continue
-		if (!(AA.stat & (NOPOWER|BROKEN)))
-			alarm_area.master_air_alarm = AA
-			return 1
-	return 0
-
 /obj/machinery/alarm/proc/get_danger_level(var/current_value, var/list/danger_levels)
 	if((current_value >= danger_levels[4] && danger_levels[4] > 0) || current_value <= danger_levels[1])
 		return 2
@@ -366,12 +346,6 @@
 	set_light(0.25, 0.1, 1, 2, new_color)
 
 /obj/machinery/alarm/receive_signal(datum/signal/signal)
-	if (alarm_area.master_air_alarm != src)
-		if (master_is_operating())
-			return
-		elect_master()
-		if (alarm_area.master_air_alarm != src)
-			return
 	if(!signal || signal.encryption)
 		return
 	if(alarm_id == signal.data["alarm_id"] && signal.data["command"] == "shutdown")

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -378,9 +378,10 @@
 		if(. & AIR_BLOCKED)
 			continue
 		var/area/A = get_area(neighbour)
-		if(!A.master_air_alarm)
-			return
 		if(A.atmosalm)
+			return
+		var/obj/machinery/alarm/alarm = locate() in A
+		if(!alarm || (alarm.stat & (NOPOWER|BROKEN)))
 			return
 	return TRUE
 


### PR DESCRIPTION
Was going to make this tracked in a more reasonable way, but turns out it doesn't even do anything worth noting. The doors check proc is far less performance sensitive than `receive_signal` is (only called from Topic and Process, latter during rare state transitions).