### PR TITLE
Monkey Cube Addition

### DIFF
--- a/maps/tradeship/tradeship-0.dmm
+++ b/maps/tradeship/tradeship-0.dmm
@@ -1207,6 +1207,12 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/access_button/airlock_interior{
+	pixel_x = 0;
+	pixel_y = 12;
+	pixel_z = -33;
+	master_tag = "lower_cargo"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/loading_bay)
 "cX" = (
@@ -1259,15 +1265,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/fore_port_underside_maint)
-"ft" = (
-/obj/machinery/access_button/airlock_exterior{
-	master_tag = "lower_cargo";
-	pixel_x = 0;
-	pixel_y = -10
-	},
-/obj/effect/paint/brown,
-/turf/simulated/wall,
-/area/ship/scrap/loading_bay)
 "fY" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -1589,14 +1586,6 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/fore_port_underside_maint)
-"vy" = (
-/obj/machinery/access_button/airlock_interior{
-	master_tag = "lower_cargo";
-	pixel_x = 0;
-	pixel_y = 12
-	},
-/turf/simulated/wall,
-/area/ship/scrap/loading_bay)
 "vP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2088,6 +2077,15 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/loading_bay)
+"WC" = (
+/obj/machinery/access_button/airlock_exterior{
+	pixel_x = 0;
+	pixel_y = -10;
+	pixel_z = 32;
+	master_tag = "lower_cargo"
+	},
+/turf/simulated/floor,
+/area/space)
 "Xo" = (
 /obj/structure/hygiene/drain,
 /turf/simulated/floor,
@@ -5282,12 +5280,12 @@ yO
 aI
 pi
 cI
-vy
+yO
 aw
 aB
 aJ
-ft
-ai
+qK
+WC
 aa
 aa
 aa

--- a/maps/tradeship/tradeship-1.dmm
+++ b/maps/tradeship/tradeship-1.dmm
@@ -927,6 +927,10 @@
 	dir = 4
 	},
 /obj/machinery/r_n_d/destructive_analyzer,
+/obj/machinery/light_switch{
+	pixel_z = 23;
+	pixel_w = -1
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/science/fabricaton)
 "ce" = (
@@ -2571,6 +2575,9 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/hydroponics,
+/obj/machinery/light_switch{
+	pixel_w = -23
+	},
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/science)
 "pb" = (
@@ -2878,10 +2885,6 @@
 /obj/machinery/door/airlock/hatch/autoname/general,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/ship/scrap/cargo/lower)
-"AT" = (
-/obj/machinery/computer/mining,
-/turf/simulated/wall,
 /area/ship/scrap/cargo/lower)
 "Bb" = (
 /obj/machinery/door/airlock/hatch/autoname/general,
@@ -3373,6 +3376,11 @@
 "WT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/mining{
+	density = 0;
+	pixel_w = 32;
+	pixel_z = 0
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/ship/scrap/cargo/lower)
 "WZ" = (
@@ -6942,7 +6950,7 @@ pr
 pr
 pr
 pr
-AT
+ao
 al
 al
 ao

--- a/maps/tradeship/tradeship-2.dmm
+++ b/maps/tradeship/tradeship-2.dmm
@@ -300,6 +300,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/light_switch{
+	pixel_w = 27
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/ship/scrap/dock)
 "bx" = (
@@ -2656,6 +2659,9 @@
 /area/space)
 "gA" = (
 /obj/machinery/washing_machine,
+/obj/item/storage/box/monkeycubes{
+	pixel_z = 13
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/ship/scrap/crew/wash)
 "gB" = (
@@ -4967,6 +4973,9 @@
 	pixel_y = 25
 	},
 /obj/machinery/biogenerator,
+/obj/machinery/light_switch{
+	pixel_w = 22
+	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/garden)
 "qc" = (
@@ -5129,9 +5138,6 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/garden)
 "sc" = (
-/obj/machinery/light_switch{
-	pixel_x = 28
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
@@ -5829,9 +5835,6 @@
 /obj/structure/cable{
 	icon_state = "0-2";
 	d2 = 2
-	},
-/obj/machinery/light_switch{
-	pixel_x = 28
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/firealarm{

--- a/maps/tradeship/tradeship-3.dmm
+++ b/maps/tradeship/tradeship-3.dmm
@@ -499,8 +499,9 @@
 /turf/simulated/floor/reinforced/airless,
 /area/space)
 "qw" = (
-/obj/item/frame/light_switch{
-	pixel_x = 24
+/obj/machinery/light_switch{
+	pixel_z = 0;
+	pixel_w = 24
 	},
 /turf/simulated/floor/plating,
 /area/ship/scrap/maintenance/solars)


### PR DESCRIPTION
<!-- 


-->Map changes - more detail than necessary included because I'm new at this and want to be a bit thorough.  
*Light switch added to solar array access.  Deleted non-functional light switch frame.
*Added box of monkey cubes to laundry room where some scav intended to perform cube related experimentation
*Ore processing console repositioned for functionality (was non-functional before), density set to 0
*Large airlock access switches (inside and outside) repositioned so as to become functional.  Time to vent some scavs
*Gee, first mate, why does your dev let you have two light switches?  Deleted second light switch in First mate's office
*Moved light switch away from ladder in docking bay
*light switch added to hydroponics
*light switches added to research rooms