### PR TITLE
Access changes to Jr Scientist, Solar access and EVA

### DIFF
--- a/maps/tradeship/tradeship_areas.dm
+++ b/maps/tradeship/tradeship_areas.dm
@@ -139,6 +139,7 @@
 /area/ship/scrap/maintenance/eva
 	name = "\improper EVA Storage"
 	icon_state = "eva"
+	req_access = list(access_eva)
 
 /area/ship/scrap/maintenance/engineering
 	name = "\improper Engineering Bay"
@@ -215,6 +216,7 @@
 /area/ship/scrap/maintenance/solars
 	name = "\improper Solar Array Access"
 	icon_state = "SolarcontrolA"
+	req_access = list(access_engine)
 
 /area/ship/scrap/maintenance/robot
 	name = "\improper Robot Storage"

--- a/maps/tradeship/tradeship_jobs.dm
+++ b/maps/tradeship/tradeship_jobs.dm
@@ -231,6 +231,8 @@
 	                    SKILL_DEVICES     = SKILL_MAX,
 	                    SKILL_SCIENCE     = SKILL_MAX)
 	skill_points = 24
+	access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
+	minimal_access = list(access_robotics, access_tox, access_tox_storage, access_research, access_xenobiology, access_xenoarch)
 
 /datum/job/yinglet
 	title = "Enclave Worker"


### PR DESCRIPTION
* Jr Scientist on tradeship now forced to have full sciencey access even on minimal access settings
* Solar Array Access area requires Engine access
* EVA now requires EVA access

Resolves #274 
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->