### PR TITLE
Generalizes some structure tool interactions.

### DIFF
--- a/code/modules/crafting/_crafting_holder.dm
+++ b/code/modules/crafting/_crafting_holder.dm
@@ -27,7 +27,7 @@
 			to_chat(user, SPAN_NOTICE("You could continue to work on this with <b>[english_list(next_steps, and_text = " or ")]</b>."))
 
 /obj/item/crafting_holder/Initialize(var/ml, var/decl/crafting_stage/initial_stage, var/obj/item/target, var/obj/item/tool, var/mob/user)
-	. = ..()
+	. = ..(ml)
 	name = "[target.name] assembly"
 	var/mob/M = target.loc
 	if(istype(M))


### PR DESCRIPTION
Hoping to get ahead on some of these material dupe bugs and clean the code up a bit in the process.

- The default deconstruction tool for structures is now welding torch for metal objects, and crowbar for others. It used to be wrench or welding torch depending on item.
- This also applies to removing the plating from simple walls (reinforced walls are still a mess).
- You can now examine a structure to see if it can be unanchored or deconstructed. I haven't added additional checks to specific structures so it won't tell you what other conditions are needed though.
- Reinforcing girders is now done by using a stack on it while it is unanchored. 
- Removing reinforcement is still screwdriver.
- You can use a screwdriver on an un-reinforced girder to toggle whether or not it will form a false wall when finished.

- [x] Test girder construction/deconstruction, anchoring/unanchoring and reinforcing.
- [x] Test firedoor construction/deconstruction.
- [x] Test water cooler anchoring/unanchoring and reagent dispenser wrenching.
- [ ] Test AI core construction/deconstruction.
- [ ] Test windoor assembly construction/deconstruction.
- [x] Test bookcase deconstruction.
- [x] Test noticeboard deconstruction.
- [x] Test bookcase materials.
- [ ] Do something about basic windows.
- [ ] Test basic windows after above.
- [ ] Do something about airlock assemblies.
- [ ] Test airlock assemblies after above.